### PR TITLE
fix: reject sub with unsafe ints in since/until

### DIFF
--- a/src/schemas/base-schema.ts
+++ b/src/schemas/base-schema.ts
@@ -12,6 +12,10 @@ export const signatureSchema = Schema.string().case('lower').hex().length(128).l
 
 export const subscriptionSchema = Schema.string().min(1).max(255).label('subscriptionId')
 
+const seconds = (value: any, helpers: any) => (Number.isSafeInteger(value) && Math.log10(value) < 10) ? value : helpers.error('any.invalid')
+
+export const createdAtSchema = Schema.number().min(0).multiple(1).custom(seconds)
+
 // [<string>, <string> 0..*]
 export const tagSchema = Schema.array()
   .ordered(Schema.string().max(255).required().label('identifier'))

--- a/src/schemas/event-schema.ts
+++ b/src/schemas/event-schema.ts
@@ -1,6 +1,7 @@
 import Schema from 'joi'
 
 import {
+  createdAtSchema,
   idSchema,
   kindSchema,
   pubkeySchema,
@@ -8,8 +9,6 @@ import {
   tagSchema,
 } from './base-schema'
 
-
-export const seconds = (value: any, helpers: any) => (Math.log10(value) < 10) ? value : helpers.error('any.invalid')
 
 /**
  * {
@@ -30,7 +29,7 @@ export const eventSchema = Schema.object({
   // NIP-01
   id: idSchema.required(),
   pubkey: pubkeySchema.required(),
-  created_at: Schema.number().min(0).multiple(1).custom(seconds).required(),
+  created_at: createdAtSchema.required(),
   kind: kindSchema.required(),
   tags: Schema.array().items(tagSchema).required(),
   content: Schema.string()

--- a/src/schemas/filter-schema.ts
+++ b/src/schemas/filter-schema.ts
@@ -1,12 +1,12 @@
 import Schema from 'joi'
 
-import { kindSchema, prefixSchema } from './base-schema'
+import { createdAtSchema, kindSchema, prefixSchema } from './base-schema'
 
 export const filterSchema = Schema.object({
   ids: Schema.array().items(prefixSchema.label('prefixOrId')).max(1000),
   authors: Schema.array().items(prefixSchema.label('prefixOrAuthor')).max(1000),
   kinds: Schema.array().items(kindSchema).max(20),
-  since: Schema.number().min(0).multiple(1),
-  until: Schema.number().min(0).multiple(1),
+  since: createdAtSchema,
+  until: createdAtSchema,
   limit: Schema.number().min(0).multiple(1).max(10000),
 }).pattern(/^#[a-z]$/, Schema.array().items(Schema.string().max(1024)).max(256))

--- a/test/unit/schemas/event-schema.spec.ts
+++ b/test/unit/schemas/event-schema.spec.ts
@@ -84,6 +84,7 @@ describe('NIP-01', () => {
         { message: 'is required', transform: omit(['pubkey']) },
       ],
       created_at: [
+        { message: 'contains an invalid value', transform: assocPath(['created_at'], 1672295751103) },
         { message: 'must be a number', transform: assocPath(['created_at'], null) },
         { message: 'must be greater than or equal to 0', transform: assocPath(['created_at'], -1) },
         { message: 'must be a multiple of 1', transform: assocPath(['created_at'], Math.PI) },

--- a/test/unit/schemas/filter-schema.spec.ts
+++ b/test/unit/schemas/filter-schema.spec.ts
@@ -58,11 +58,13 @@ describe('NIP-01', () => {
         { message: 'must be a multiple of 1', transform: assocPath(['kinds', 0], Math.PI) },
       ],
       since: [
+        { message: 'contains an invalid value', transform: assocPath(['since'], 1672295751103) },
         { message: 'must be a number', transform: assocPath(['since'], null) },
         { message: 'must be greater than or equal to 0', transform: assocPath(['since'], -1) },
         { message: 'must be a multiple of 1', transform: assocPath(['since'], Math.PI) },
       ],
       until: [
+        { message: 'contains an invalid value', transform: assocPath(['until'], 1672295751103) },
         { message: 'must be a number', transform: assocPath(['until'], null) },
         { message: 'must be greater than or equal to 0', transform: assocPath(['until'], -1) },
         { message: 'must be a multiple of 1', transform: assocPath(['until'], Math.PI) },


### PR DESCRIPTION
Signed-off-by: Ricardo Arturo Cabral Mejía <me@ricardocabral.io>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. Reject subscriptions with unsafe integers in since/until 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Cameri/nostream/issues/110

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
1. Unsafe integers cause errors when querying the database

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Unit tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Non-functional change (docs, style, minor refactor)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my code changes.
- [x] All new and existing tests passed.
