### PR TITLE
Add reverse proxy for local dev

### DIFF
--- a/.nostr.local/certs/.gitignore
+++ b/.nostr.local/certs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/.nostr.local/settings.json
+++ b/.nostr.local/settings.json
@@ -1,7 +1,7 @@
 {
   "info": {
-    "relay_url": "wss://nostream.your-domain.com",
-    "name": "nostream.your-domain.com",
+    "relay_url": "wss://nostream.localtest.me",
+    "name": "nostream.localtest.me",
     "description": "A nostr relay written in TypeScript.",
     "pubkey": "replace-with-your-pubkey",
     "contact": "operator@your-domain.com"

--- a/Caddyfile.local
+++ b/Caddyfile.local
@@ -1,0 +1,9 @@
+{
+	auto_https disable_certs
+}
+
+nostream.localtest.me {
+	tls /root/certs/nostream.localtest.me.pem /root/certs/nostream.localtest.me-key.pem
+
+	reverse_proxy nostr-ts-relay:8008
+}

--- a/README.md
+++ b/README.md
@@ -70,7 +70,11 @@ NIPs with a relay-specific implementation are listed here.
 
 ### Docker setups
 - Docker v20.10
-- Docker compose v2.10
+- Docker Compose v2.10
+
+### Local Docker setup
+- Docker Desktop v4.2.0 or newer
+- [mkcert](https://github.com/FiloSottile/mkcert)
 
 WARNING: Docker distributions from Snap, Brew or Debian repositories are NOT SUPPORTED and will result in errors.
 Install Docker from their [official guide](https://docs.docker.com/engine/install/) ONLY.
@@ -78,6 +82,24 @@ Install Docker from their [official guide](https://docs.docker.com/engine/instal
 ## Full Guide
 
 - [Set up a Nostr relay in under 5 minutes](https://andreneves.xyz/p/set-up-a-nostr-relay-server-in-under) by [André Neves](https://twitter.com/andreneves) (CTO & Co-Founder At [ZEBEDEE](https://zebedee.io/))
+
+## Local Quick Start (Docker Compose)
+
+Install Docker Desktop following the [official guide](https://docs.docker.com/desktop/).
+You may have to uninstall Docker on your machine if you installed it using a different guide.
+
+Clone repository and enter directory:
+  ```
+  git clone git@github.com:Cameri/nostream.git
+  cd nostream
+  ```
+
+Start:
+  ```
+  ./scripts/start_local
+  ```
+
+  This will run in the foreground of the terminal until you stop it with Ctrl+C.
 
 ## Quick Start (Docker Compose)
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,23 @@
+services:
+  relay:
+    volumes:
+      - ${PWD}/.nostr.local:/home/node/
+  caddy:
+    image: caddy:2.6.2-alpine
+    container_name: caddy
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - ${PWD}/Caddyfile.local:/etc/caddy/Caddyfile
+      - ${PWD}/.nostr.local/certs:/root/certs/
+      - caddydata:/data
+      - caddyconfig:/config
+    restart: unless-stopped
+    networks:
+      default:
+        ipv4_address: 10.10.10.5
+
+volumes:
+  caddyconfig:
+  caddydata:

--- a/scripts/start_local
+++ b/scripts/start_local
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+PROJECT_ROOT="$(dirname $(readlink -f "${BASH_SOURCE[0]}"))/.."
+DOCKER_COMPOSE_FILE="${PROJECT_ROOT}/docker-compose.yml"
+DOCKER_COMPOSE_LOCAL_FILE="${PROJECT_ROOT}/docker-compose.local.yml"
+
+if ! type "mkcert" &> /dev/null; then
+  echo "Could not find mkcert, which is required for generating locally-trusted TLS certificates. Follow the installation instructions at https://github.com/FiloSottile/mkcert, then run this script again."
+  exit 1
+fi
+
+mkcert -install
+mkcert \
+  -cert-file ${PROJECT_ROOT}/.nostr.local/certs/nostream.localtest.me.pem \
+  -key-file ${PROJECT_ROOT}/.nostr.local/certs/nostream.localtest.me-key.pem \
+  nostream.localtest.me
+
+docker compose \
+  -f $DOCKER_COMPOSE_FILE \
+  -f $DOCKER_COMPOSE_LOCAL_FILE \
+  up --build --remove-orphans $@


### PR DESCRIPTION
Includes locally-trusted TLS certs via mkcert and uses a hostname that already points to 127.0.0.1 without having to modify the hosts file.

## Description
This change makes it easy to spin up a local environment for development, both for enhancements to the relay and for use while developing a nostr client. It uses [Caddy](https://caddyserver.com/) as the reverse-proxy, [mkcert](https://github.com/FiloSottile/mkcert) to generate certs for the hostname that are trusted on the developer's machine, and a [localtest.me](https://readme.localtest.me/) subdomain for the hostname to avoid requiring a change to the machine's host file.

## Related Issue
#117

## Motivation and Context
Quickly overcomes the barrier to getting the relay working in a local environment. Anything that makes the relay easier to use will help boost adoption and contributions to the project.

## How Has This Been Tested?
I was able to reliably spin up the relay from zero state, connect to wss://nostream.localtest.me with [WebSocket King](https://websocketking.com/), and receive test events from [astral.ninja](https://astral.ninja/) configured to only use wss://nostream.localtest.me.

@Cameri I haven't updated docs or run tests yet because I'm considering this PR a draft. I wanted to check with you on expectations. Is the existing Docker Compose configuration meant for local or prod use? I made changes to it assuming that it was meant for local, but I can easily split these changes off to a dedicated local version if you'd like.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Non-functional change (docs, style, minor refactor)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my code changes.
- [ ] All new and existing tests passed.