### PR TITLE
fix: bug typeerror cannot read properties of undefined reading   knexuid

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -6,25 +6,26 @@ The following environment variables can be set:
 
 | Name                  | Description                    | Default                |
 |-----------------------|--------------------------------|------------------------|
-| RELAY_PORT            | Relay's server port            | 8008                   |
-| WORKER_COUNT          | Number of workers override     | No. of available CPUs  |
-| DB_HOST               | PostgresSQL Hostname           |                        |
-| DB_PORT               | PostgreSQL Port                | 5432                   |
-| DB_USER               | PostgreSQL Username            | nostr_ts_relay         |
-| DB_PASSWORD           | PostgreSQL Password            | nostr_ts_relay         |
-| DB_NAME               | PostgreSQL Database name       | nostr_ts_relay         |
-| DB_MIN_POOL_SIZE      | Min. connections per worker    | 16                     |
-| DB_MAX_POOL_SIZE      | Max. connections per worker    | 32                     |
-| TOR_HOST              | Tor Hostname                   |                        |
-| TOR_CONTROL_PORT      | Tor control Port               | 9051                   |
-| TOR_PASSWORD          | Tor control password           | nostr_ts_relay         |
-| HIDDEN_SERVICE_PORT   | Tor hidden service port        | 80                     |
-| REDIS_HOST            |                                |                        |
-| REDIS_PORT            | Redis Port                     | 6379                   |
-| REDIS_USER            | Redis User                     | default                |
-| REDIS_PASSWORD        | Redis Password                 | nostr_ts_relay         |
-| NOSTR_CONFIG_DIR      | Configuration directory        | <project_root>/.nostr/ |
-| DEBUG                 | Debugging filter               |                        |
+| RELAY_PORT                    | Relay's server port            | 8008                   |
+| WORKER_COUNT                  | Number of workers override     | No. of available CPUs  |
+| DB_HOST                       | PostgresSQL Hostname           |                        |
+| DB_PORT                       | PostgreSQL Port                | 5432                   |
+| DB_USER                       | PostgreSQL Username            | nostr_ts_relay         |
+| DB_PASSWORD                   | PostgreSQL Password            | nostr_ts_relay         |
+| DB_NAME                       | PostgreSQL Database name       | nostr_ts_relay         |
+| DB_MIN_POOL_SIZE              | Min. connections per worker    | 16                     |
+| DB_MAX_POOL_SIZE              | Max. connections per worker    | 32                     |
+| DB_ACQUIRE_CONNECTION_TIMEOUT | New connection timeout (ms)    | 60000                  |
+| TOR_HOST                      | Tor Hostname                   |                        |
+| TOR_CONTROL_PORT              | Tor control Port               | 9051                   |
+| TOR_PASSWORD                  | Tor control password           | nostr_ts_relay         |
+| HIDDEN_SERVICE_PORT           | Tor hidden service port        | 80                     |
+| REDIS_HOST                    |                                |                        |
+| REDIS_PORT                    | Redis Port                     | 6379                   |
+| REDIS_USER                    | Redis User                     | default                |
+| REDIS_PASSWORD                | Redis Password                 | nostr_ts_relay         |
+| NOSTR_CONFIG_DIR              | Configuration directory        | <project_root>/.nostr/ |
+| DEBUG                         | Debugging filter               |                        |
 
 # Settings
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       DB_NAME: nostr_ts_relay
       DB_MIN_POOL_SIZE: 16
       DB_MAX_POOL_SIZE: 64
+      DB_ACQUIRE_CONNECTION_TIMEOUT: 60000
       REDIS_HOST: cache
       REDIS_PORT: 6379
       REDIS_USER: default

--- a/src/app/worker.ts
+++ b/src/app/worker.ts
@@ -29,7 +29,9 @@ export class AppWorker implements IRunnable {
 
   private onError(error: Error) {
     if (error.name === 'TypeError' && error.message === "Cannot read properties of undefined (reading '__knexUid')") {
-      console.error('Unable to acquire connection. Please increase DB_MAX_POOL_SIZE, ')
+      console.error(
+        'Unable to acquire connection. Please increase DB_MAX_POOL_SIZE, DB_ACQUIRE_CONNECTION_TIMEOUT and tune postgresql.conf to make use of server\'s resources.'
+      )
       return
     }
     console.error('uncaught error:', error)

--- a/src/app/worker.ts
+++ b/src/app/worker.ts
@@ -28,8 +28,11 @@ export class AppWorker implements IRunnable {
   }
 
   private onError(error: Error) {
-    debug('error: %o', error)
-    throw error
+    if (error.name === 'TypeError' && error.message === "Cannot read properties of undefined (reading '__knexUid')") {
+      console.error('Unable to acquire connection. Please increase DB_MAX_POOL_SIZE, ')
+      return
+    }
+    console.error('uncaught error:', error)
   }
 
   private onExit() {

--- a/src/database/client.ts
+++ b/src/database/client.ts
@@ -17,10 +17,15 @@ const createDbConfig = (): Knex.Config => ({
   pool: {
     min: process.env.DB_MIN_POOL_SIZE ? Number(process.env.DB_MIN_POOL_SIZE) : 0,
     max: process.env.DB_MAX_POOL_SIZE ? Number(process.env.DB_MAX_POOL_SIZE) : 3,
-    idleTimeoutMillis: 10000,
+    idleTimeoutMillis: 60000,
     propagateCreateError: false,
+    acquireTimeoutMillis: process.env.DB_ACQUIRE_CONNECTION_TIMEOUT
+    ? Number(process.env.DB_ACQUIRE_CONNECTION_TIMEOUT)
+    : 60000,
   },
-  acquireConnectionTimeout: 30000,
+  acquireConnectionTimeout: process.env.DB_ACQUIRE_CONNECTION_TIMEOUT
+    ? Number(process.env.DB_ACQUIRE_CONNECTION_TIMEOUT)
+    : 60000,
 })
 
 let client: Knex


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Fixes #140 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
1. Under load, Nostream takes a little longer to acquire a new connection, in some cases it is unable to acquire and an error is thrown causing the worker to crash. All clients connected to the worker would lose connection.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Lowered acquireConnectionTimeout in order to replicate the issue
2. Ran Nostream and conducted requests and sent events

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Non-functional change (docs, style, minor refactor)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my code changes.
- [x] All new and existing tests passed.
