### PR TITLE
fix: SettingsStatic class default to yaml file

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -37,8 +37,8 @@ export class App implements IRunnable {
   }
 
   public run(): void {
-    this.watchers = SettingsStatic.watchSettings()
     const settings = this.settings()
+    this.watchers = SettingsStatic.watchSettings()
     console.log(`
  ███▄    █  ▒█████    ██████ ▄▄▄█████▓ ██▀███  ▓█████ ▄▄▄       ███▄ ▄███▓
  ██ ▀█   █ ▒██▒  ██▒▒██    ▒ ▓  ██▒ ▓▒▓██ ▒ ██▒▓█   ▀▒████▄    ▓██▒▀█▀ ██▒

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -45,8 +45,12 @@ export class SettingsStatic {
     const filteredFile = files.find(fn => fn.startsWith('settings'))
     if (filteredFile) {
       const extension = extname(filteredFile).substring(1)
-      return SettingsFileTypes[extension]
+      if (SettingsFileTypes[extension]) {
+        return SettingsFileTypes[extension]
+      }
     }
+
+    return SettingsFileTypes.yaml
   }
 
   public static loadSettings(path: string, fileType: SettingsFileTypes) {

--- a/test/integration/features/shared.ts
+++ b/test/integration/features/shared.ts
@@ -11,6 +11,7 @@ import {
 import { assocPath, pipe } from 'ramda'
 import { fromEvent, map, Observable, ReplaySubject, Subject, takeUntil } from 'rxjs'
 import WebSocket, { MessageEvent } from 'ws'
+import Sinon from 'sinon'
 
 import { connect, createIdentity, createSubscription, sendEvent } from './helpers'
 import { getMasterDbClient, getReadReplicaDbClient } from '../../../src/database/client'
@@ -21,7 +22,6 @@ import { Event } from '../../../src/@types/event'
 import { getCacheClient } from '../../../src/cache/client'
 import { SettingsStatic } from '../../../src/utils/settings'
 import { workerFactory } from '../../../src/factories/worker-factory'
-import Sinon from 'sinon'
 
 export const isDraft = Symbol('draft')
 

--- a/test/integration/features/shared.ts
+++ b/test/integration/features/shared.ts
@@ -21,6 +21,7 @@ import { Event } from '../../../src/@types/event'
 import { getCacheClient } from '../../../src/cache/client'
 import { SettingsStatic } from '../../../src/utils/settings'
 import { workerFactory } from '../../../src/factories/worker-factory'
+import Sinon from 'sinon'
 
 export const isDraft = Symbol('draft')
 
@@ -38,7 +39,7 @@ BeforeAll({ timeout: 1000 }, async function () {
   dbClient = getMasterDbClient()
   rrDbClient = getReadReplicaDbClient()
   await dbClient.raw('SELECT 1=1')
-
+  Sinon.stub(SettingsStatic, 'watchSettings')
   const settings = SettingsStatic.createSettings()
 
   SettingsStatic._settings = pipe(


### PR DESCRIPTION
## Description
This patch fixes scenarios where the user renamed the settings file to `settings.json.<something>` which caused the settings setup script to concatenate the settings name incorrectly

## Related Issue
N/A

## Motivation and Context
Fixes a bug

## How Has This Been Tested?
Local reproduction of issue

## Screenshots (if appropriate):

## Types of changes
Update of a method, no backward compatiblity implications

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my code changes.
- [x] All new and existing tests passed.
