### PR TITLE
Pre-load dotenv to properly load db env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Install dependencies:
 Run migrations (at least once and after pulling new changes):
 
   ```
-  npm run db:migrate
+  NODE_OPTIONS="-r dotenv/config" npm run db:migrate
   ```
 
 Create .nostr folder inside nostream project folder:


### PR DESCRIPTION
Minor update to README for UX. 

## Description

Adding a `NODE_OPTIONS` preface to the command to pre-load dotenv

## Motivation and Context

When a user specifies custom database parameters in `.env`, these are not currently loaded during an `npm run db:migrate`. Pre-loading dotenv through the `NODE_OPTIONS` is a low-lift one-line option to assist someone walking step-by-step through the instructions.

## How Has This Been Tested?

Personal experience:)

## Screenshots (if appropriate):

<img width="613" alt="Screen Shot 2023-02-08 at 5 17 10 PM" src="https://user-images.githubusercontent.com/7146063/217681533-b13b380d-4f48-49f1-9560-17922fc33058.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Non-functional change (docs, style, minor refactor)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my code changes.
- [x] All new and existing tests passed.
