### PR TITLE
Fix instructions to run locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Set the following environment variables:
 
   ```
   DB_URI="postgresql://postgres:postgres@localhost:5432/nostr_ts_relay_test"
+  DB_USER=postgres
 
   or
 
@@ -236,10 +237,11 @@ Run migrations (at least once and after pulling new changes):
   npm run db:migrate
   ```
 
-Create .nostr folder inside nostream project folder:
+Create .nostr folder inside nostream project folder and copy over the settings file:
 
   ```
   mkdir .nostr
+  cp resources/default-settings.yaml .nostr/settings.yaml
   ```
 
 To start in development mode:


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- I had to set `DB_USER` seperately for the DB migrations to run.
- I had to copy over the `settings.yaml` file because it wasn't created by default.
