### PR TITLE
Disclose limits better at runtime in `relayInformationDocument`

### DIFF
--- a/src/handlers/request-handlers/root-request-handler.ts
+++ b/src/handlers/request-handlers/root-request-handler.ts
@@ -32,7 +32,7 @@ export const rootRequestHandler = (request: Request, response: Response, next: N
             max_subid_length: 256,
             min_prefix: 4,
             max_event_tags: 2500,
-            max_content_length: 102400,
+            max_content_length: settings.limits.event.content,
             min_pow_difficulty: settings.limits.event.eventId.minLeadingZeroBits,
             auth_required: false,
             payment_required: settings.payments.enabled,

--- a/src/handlers/request-handlers/root-request-handler.ts
+++ b/src/handlers/request-handlers/root-request-handler.ts
@@ -29,7 +29,6 @@ export const rootRequestHandler = (request: Request, response: Response, next: N
             max_payload_size: settings.network.maxPayloadSize,
             max_subscriptions: settings.limits.client.subscription.maxSubscriptions,
             max_filters: settings.limits.client.subscription.maxFilters,
-            max_limit: 5000,
             max_subid_length: 256,
             min_prefix: 4,
             max_event_tags: 2500,

--- a/src/handlers/request-handlers/root-request-handler.ts
+++ b/src/handlers/request-handlers/root-request-handler.ts
@@ -26,7 +26,7 @@ export const rootRequestHandler = (request: Request, response: Response, next: N
       software: packageJson.repository.url,
       version: packageJson.version,
       limitation: {
-            max_message_length: settings.network.maxPayloadSize,
+            max_payload_size: settings.network.maxPayloadSize,
             max_subscriptions: settings.limits.client.subscription.maxSubscriptions,
             max_filters: settings.limits.client.subscription.maxFilters,
             max_limit: 5000,


### PR DESCRIPTION
Clarifies limits advertised systematically in the `relayInformationDocument` accessible from a `GET` to the relay over HTTP.

## Description
* renames `max_message_length` to `max_payload_size`
* removes `max_limit`
* changes `max_content_length` from an (irrelevant?) constant to an object describing the content limits by event type.

## Motivation and Context
* I was personally confused between this object and the config.  I still might be. 😅 



## How Has This Been Tested?
I hit the following command on my local.  

`curl -X GET http://localhost:8008 -H 'accept: application/nostr+json' | jq`

## Screenshots (if appropriate):

```json

{
  "name": "nostream.your-domain.com",
  "description": "A nostr relay written in Typescript.",
  "pubkey": "replace-with-your-pubkey-in-hex",
  "contact": "operator@your-domain.com",
  "supported_nips": [
    1,
    2,
    4,
    9,
    11,
    12,
    15,
    16,
    20,
    22,
    26,
    28,
    33,
    40,
    111
  ],
  "software": "git+https://github.com/Cameri/nostream.git",
  "version": "1.22.2",
  "limitation": {
    "max_payload_size": 524288,
    "max_subscriptions": 10,
    "max_filters": 10,
    "max_subid_length": 256,
    "min_prefix": 4,
    "max_event_tags": 2500,
    "max_content_length": [
      {
        "description": "64 KB for event kind ranges 0-10 and 40-49",
        "kinds": [
          [
            0,
            10
          ],
          [
            40,
            49
          ]
        ],
        "maxLength": 65536
      },
      {
        "description": "96 KB for event kind ranges 11-39 and 50-max",
        "kinds": [
          [
            11,
            39
          ],
          [
            50,
            9007199254740991
          ]
        ],
        "maxLength": 98304
      }
    ],
    "min_pow_difficulty": 0,
    "auth_required": false,
    "payment_required": false
  },
  "payments_url": "https://nostream.your-domain.com/invoices",
  "fees": {
    "admission": []
  }
}

```
## Types of changes
- [x] Non-functional change (docs, style, minor refactor)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my code changes.
- [ ] All new and existing tests passed.

...I think this matches docs now.  If for some reason this PR is rejected, then I'd say docs need updating.

I didn't try to run the tests.  LMK if I really need to figure it out for this.
