### PR TITLE
Added directory check to start scripts

### DIFF
--- a/scripts/start
+++ b/scripts/start
@@ -4,6 +4,15 @@ DOCKER_COMPOSE_FILE="${PROJECT_ROOT}/docker-compose.yml"
 NOSTR_CONFIG_DIR="${PROJECT_ROOT}/.nostr"
 SETTINGS_FILE="${NOSTR_CONFIG_DIR}/settings.yaml"
 DEFAULT_SETTINGS_FILE="${PROJECT_ROOT}/resources/default-settings.yaml"
+CURRENT_DIR=$(pwd)
+
+if [[ ${CURRENT_DIR} =~ /scripts$ ]]; then
+        echo "Please run this script from the Nostream root folder, not the scripts directory."
+        echo "To do this, change up one directory, and then run the following command:"
+        echo "./scripts/start"
+        exit 1
+fi
+
 
 if [ "$EUID" -eq 0 ]
   then echo "Error: Nostream should not be run as root."

--- a/scripts/start_local
+++ b/scripts/start_local
@@ -4,6 +4,14 @@ set -e
 PROJECT_ROOT="$(dirname $(readlink -f "${BASH_SOURCE[0]}"))/.."
 DOCKER_COMPOSE_FILE="${PROJECT_ROOT}/docker-compose.yml"
 DOCKER_COMPOSE_LOCAL_FILE="${PROJECT_ROOT}/docker-compose.local.yml"
+CURRENT_DIR=$(pwd)
+
+if [[ ${CURRENT_DIR} =~ /scripts$ ]]; then
+        echo "Please run this script from the Nostream root folder, not the scripts directory."
+        echo "To do this, change up one directory, and then run the following command:"
+        echo "./scripts/start"
+        exit 1
+fi
 
 if [ "$EUID" -eq 0 ]
   then echo "Error: Nostream should not be run as root."

--- a/scripts/start_with_tor
+++ b/scripts/start_with_tor
@@ -6,6 +6,14 @@ TOR_DATA_DIR="$PROJECT_ROOT/.nostr/tor/data"
 NOSTR_CONFIG_DIR="${PROJECT_ROOT}/.nostr"
 SETTINGS_FILE="${NOSTR_CONFIG_DIR}/settings.yaml"
 DEFAULT_SETTINGS_FILE="${PROJECT_ROOT}/resources/default-settings.yaml"
+CURRENT_DIR=$(pwd)
+
+if [[ ${CURRENT_DIR} =~ /scripts$ ]]; then
+        echo "Please run this script from the Nostream root folder, not the scripts directory."
+        echo "To do this, change up one directory, and then run the following command:"
+        echo "./scripts/start"
+        exit 1
+fi
 
 if [ "$EUID" -eq 0 ]
   then echo "Error: Nostream should not be run as root."


### PR DESCRIPTION
Added a check to the start scripts to ensure they are being run from the correct directory. Informs user if they're being run from /scripts/ directly and provides a descriptive error message.
Fixes #218

## Description

If the start script(s) are run from the incorrect directory this currently throws a confusing error message.
This fix checks the directory the script is being run from and will alert the user if they're running it from the wrong directory.

## Related Issue
#218 

## Motivation and Context

I encountered this problem myself when testing Nostream, and found an issue had already been raised, so I assume others will be making the same mistake and assuming it's "safe" to run ./start from within the scripts folder.  Adding a simple message to the script will save people time troubleshooting postgres errors.

## How Has This Been Tested?

Tested on Ubuntu Server 22.04

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Non-functional change (docs, style, minor refactor)
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my code changes.
- [ ] All new and existing tests passed.
