### PR TITLE
fix: add SECRET as env variable to docker-compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ Clone repository and enter directory:
   cd nostream
   ```
 
+Generate a secret with: `openssl rand -hex 128`
+Copy the output and paste it into an `.env` file:
+
+  ```
+  SECRET=aaabbbccc...dddeeefff
+  # Secret shortened for brevity
+  ```
+
 Start:
   ```
   ./scripts/start
@@ -185,8 +193,8 @@ Set the following environment variables:
   REDIS_PASSWORD=nostr_ts_relay
   ```
 
-If enabling payments, generate a long random secret and set SECRET:
-  You may want to use `openssl rand -hex 128` to generate a secret.
+Generate a long random secret and set SECRET:
+You may want to use `openssl rand -hex 128` to generate a secret.
 
   ```
   SECRET=aaabbbccc...dddeeefff

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     build: .
     container_name: nostream
     environment:
+      SECRET: ${SECRET}
       RELAY_PORT: 8008
       # Master
       NOSTR_CONFIG_DIR: /home/node/.nostr


### PR DESCRIPTION
This might close #284

## Description
The `SECRET` env variable is mandatory by now, but the README and the `docker-compose.yml` don't reflect this.
People running the service as docker will run into the following error: 

`web-socket-adapter: unable to handle message: Error: SECRET environment variable not set`

This can be fixed setting up a secret and providing it via a `.env` file in the `docker-compose.yml`.

## Related Issue

#284 

## Motivation and Context

see description

## How Has This Been Tested?

I tested it with my own relay.
Before I was not able to send events. I did get no error message, but no success or "OK" response as well.
Now I am.

## Screenshots (if appropriate):

## Types of changes

- [X] Non-functional change (docs, style, minor refactor)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my code changes.
- [X] All new and existing tests passed.
