### PR TITLE
chore: use mailto: scheme for info.contact in settings

### DIFF
--- a/resources/default-settings.yaml
+++ b/resources/default-settings.yaml
@@ -3,7 +3,7 @@ info:
   name: nostream.your-domain.com
   description: A nostr relay written in Typescript.
   pubkey: replace-with-your-pubkey-in-hex
-  contact: operator@your-domain.com
+  contact: mailto:operator@your-domain.com
 payments:
   enabled: false
   processor: zebedee


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. Add `mailto:` URI scheme to `info.contact` in default-settings.yaml

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Cameri/nostream/issues/299

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Non-functional change (docs, style, minor refactor)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my code changes.
- [ ] All new and existing tests passed.
