### PR TITLE
fix: generic tag queries not accepting uppercase letters

### DIFF
--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -1,1 +1,1 @@
-export const isGenericTagQuery = (key: string) => /^#[a-z]$/.test(key)
+export const isGenericTagQuery = (key: string) => /^#[a-zA-Z]$/.test(key)

--- a/test/unit/utils/filter.ts
+++ b/test/unit/utils/filter.ts
@@ -1,0 +1,21 @@
+import { expect } from 'chai'
+
+import { isGenericTagQuery } from '../../../src/utils/filter'
+
+describe('isGenericTagQuery', () => {
+  it('returns true for #a', () => {
+    expect(isGenericTagQuery('#a')).to.be.true
+  })
+
+  it('returns true for #A', () => {
+    expect(isGenericTagQuery('#A')).to.be.true
+  })
+
+  it('returns false for #0', () => {
+    expect(isGenericTagQuery('#0')).to.be.false
+  })
+
+  it('returns false for #abc', () => {
+    expect(isGenericTagQuery('#abc')).to.be.false
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allow generic tag queries to be in uppercase.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Cameri/nostream/issues/311

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
NIP-12 does not mention tags should be lowercase, meaning uppercase letters should also be allowed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Non-functional change (docs, style, minor refactor)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my code changes.
- [x] All new and existing tests passed.
