### PR TITLE
fix: zebedee callback not marking invoice as paid

### DIFF
--- a/src/controllers/callbacks/zebedee-callback-controller.ts
+++ b/src/controllers/callbacks/zebedee-callback-controller.ts
@@ -75,7 +75,7 @@ export class ZebedeeCallbackController implements IController {
     try {
       await this.paymentsService.confirmInvoice({
         id: invoice.id,
-        confirmedAt: updatedInvoice.confirmedAt,
+        confirmedAt: invoice.confirmedAt,
         amountPaid: invoice.amountRequested,
       })
       await this.paymentsService.sendInvoiceUpdateNotification(updatedInvoice)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. Fix Zebedee callback incorrectly passing confirmedAt when confirming invoice

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Cameri/nostream/issues/317

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
1. Nostream v1.25.0 with zebedee as payments processor fails to confirm invoice

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Non-functional change (docs, style, minor refactor)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my code changes.
- [x] All new and existing tests passed.
