### PR TITLE
feat: add nodeinfo support

### DIFF
--- a/src/handlers/request-handlers/nodeinfo-handler.ts
+++ b/src/handlers/request-handlers/nodeinfo-handler.ts
@@ -1,0 +1,40 @@
+import { NextFunction, Request, Response } from 'express'
+import packageJson from '../../../package.json'
+
+export const nodeinfoHandler = (req: Request, res: Response, next: NextFunction) => {
+  res.json({
+    links: [{
+      rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0',
+      href: `https://${req.hostname}/nodeinfo/2.0`,
+    }, {
+      rel: 'http://nodeinfo.diaspora.software/ns/schema/2.1',
+      href: `https://${req.hostname}/nodeinfo/2.1`,
+    }],
+  }).send()
+  next()
+}
+
+export const nodeinfo21Handler = (_req: Request, res: Response, next: NextFunction) => {
+  res.json({
+    version: '2.1',
+    software: {
+      name: 'nostream',
+      version: packageJson.version,
+      repository: packageJson.repository.url,
+      homepage: packageJson.homepage,
+    },
+    protocols: ['nostr'],
+    services: {
+      inbound: [],
+      outbound: [],
+    },
+    openRegistrations: true,
+    usage: {
+      users: {},
+    },
+    metadata: {
+      features: ['nostr_relay'],
+    },
+  }).send()
+  next()
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,5 +1,6 @@
 import express from 'express'
 
+import { nodeinfo21Handler, nodeinfoHandler } from '../handlers/request-handlers/nodeinfo-handler'
 import callbacksRouter from './callbacks'
 import { getHealthRequestHandler } from '../handlers/request-handlers/get-health-request-handler'
 import { getTermsRequestHandler } from '../handlers/request-handlers/get-terms-request-handler'
@@ -12,6 +13,10 @@ const router = express.Router()
 router.get('/', rootRequestHandler)
 router.get('/healthz', getHealthRequestHandler)
 router.get('/terms', getTermsRequestHandler)
+
+router.get('/.well-known/nodeinfo', nodeinfoHandler)
+router.get('/nodeinfo/2.1', nodeinfo21Handler)
+router.get('/nodeinfo/2.0', nodeinfo21Handler)
 
 router.use('/invoices', rateLimiterMiddleware, invoiceRouter)
 router.use('/callbacks', rateLimiterMiddleware, callbacksRouter)


### PR DESCRIPTION
## Description

Adds support for [nodeinfo](https://github.com/jhass/nodeinfo) a standard of decentralized social networks. It will allow nostream relays to be indexed on sites like [FediDB](https://fedidb.org/) by adhering to a common format of decentralized networks of the past. It's similar in concept to nip11 but for more general use across different protocols.

## Related Issue

I didn't open an issue first, my mistake.

## Motivation and Context

It will open doors to greater interoperability between decentralized protocols.

## How Has This Been Tested?

I ran it in the local Docker environment and it works.

## Types of changes
- [ ] Non-functional change (docs, style, minor refactor)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my code changes.
- [x] All new and existing tests passed.
