### PR TITLE
chore: convert info.pubkey from bech32 to hex for nip-11

### DIFF
--- a/src/handlers/request-handlers/root-request-handler.ts
+++ b/src/handlers/request-handlers/root-request-handler.ts
@@ -3,6 +3,7 @@ import { path } from 'ramda'
 
 import { createSettings } from '../../factories/settings-factory'
 import { FeeSchedule } from '../../@types/settings'
+import { fromBech32 } from '../../utils/transform'
 import packageJson from '../../../package.json'
 
 export const rootRequestHandler = (request: Request, response: Response, next: NextFunction) => {
@@ -10,7 +11,7 @@ export const rootRequestHandler = (request: Request, response: Response, next: N
 
   if (request.header('accept') === 'application/nostr+json') {
     const {
-      info: { name, description, pubkey, contact, relay_url },
+      info: { name, description, pubkey: rawPubkey, contact, relay_url },
     } = settings
 
     const paymentsUrl = new URL(relay_url)
@@ -18,6 +19,10 @@ export const rootRequestHandler = (request: Request, response: Response, next: N
     paymentsUrl.pathname = '/invoices'
 
     const content = settings.limits?.event?.content
+
+    const pubkey = rawPubkey.startsWith('npub1')
+      ? fromBech32(rawPubkey)
+      : rawPubkey
 
     const relayInformationDocument = {
       name,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. Parse npubs from info.pubkey from bech32 to hex for the NIP-11 document

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Cameri/nostream/issues/331

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Mike Dilger asked for it.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With `curl -H 'Accept: application/nostr+json' http://127.0.0.1:8008/`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Non-functional change (docs, style, minor refactor)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my code changes.
- [x] All new and existing tests passed.
