### PR TITLE
docs: add note to configration readme

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -62,7 +62,7 @@ If you've set READ_REPLICAS to 4, you should configure RR0_ through RR3_.
 
 # Settings
 
-Running `nostream` for the first time creates the settings file in `<project_root>/.nostr/settings.yaml`. If the file is not created and an error is thrown ensure that the `<project_root>/.nostr` folder exists. The configuration directory can be changed by setting the `NOSTR_CONFIG_DIR` environment variable.
+Running `nostream` for the first time creates the settings file in `<project_root>/.nostr/settings.yaml`. If the file is not created and an error is thrown ensure that the `<project_root>/.nostr` folder exists. The configuration directory can be changed by setting the `NOSTR_CONFIG_DIR` environment variable. `nostream` will pick up any changes to this settings file without needing to restart.
 
 | Name                                        | Description                                                                   |
 |---------------------------------------------|-------------------------------------------------------------------------------|


### PR DESCRIPTION
## Description
Adding one line to explain that `nostream` will dynamically pick up any changes to the `settings.yaml` file.

## Related Issue
Not an issue, just trying to help inform others who might have the same question.