### PR TITLE
fix: save event from mirrors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ dist
 
 # Nostr data folder
 .nostr
+
+# Docker Compose overrides
+docker-compose.overrides.yml

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -87,6 +87,7 @@ Running `nostream` for the first time creates the settings file in `<project_roo
 | paymentProcessors.lnurl.invoiceURL          | [LUD-06 Pay Request](https://github.com/lnurl/luds/blob/luds/06.md) provider URL. (e.g. https://getalby.com/lnurlp/your-username) |
 | mirroring.static[].address                  | Address of mirrored relay. (e.g. ws://100.100.100.100:8008) |
 | mirroring.static[].filters                  | Subscription filters used to mirror. |
+| mirroring.static[].limits.event                   | Event limit overrides for this mirror. See configurations under limits.event. |
 | mirroring.static[].secret                   | Secret to pass to relays. Nostream relays only. Optional. |
 | workers.count                               | Number of workers to spin up to handle incoming connections. |
 |                                             | Spin workers as many CPUs are available when set to zero. Defaults to zero. |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine3.16 as build
+FROM node:18-alpine3.16 AS build
 
 WORKDIR /build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
     restart: on-failure
     networks:
       default:
+
   nostream-db:
     image: postgres
     container_name: nostream-db
@@ -96,6 +97,7 @@ services:
       timeout: 5s
       retries: 5
       start_period: 360s
+
   nostream-cache:
     image: redis:7.0.5-alpine3.16
     container_name: nostream-cache
@@ -110,6 +112,7 @@ services:
       interval: 1s
       timeout: 5s
       retries: 5
+
   nostream-migrate:
     image: node:18-alpine3.16
     container_name: nostream-migrate
@@ -131,7 +134,6 @@ services:
         condition: service_healthy
     networks:
       default:
-        ipv4_address: 10.10.10.254
 
 networks:
   default:

--- a/src/@types/settings.ts
+++ b/src/@types/settings.ts
@@ -203,6 +203,9 @@ export interface Mirror {
   address: string
   filters?: SubscriptionFilter[]
   secret?: Secret
+  limits?: {
+    event?: EventLimits
+  }
 }
 
 export interface Mirroring {

--- a/src/app/static-mirroring-worker.ts
+++ b/src/app/static-mirroring-worker.ts
@@ -1,12 +1,15 @@
-import { anyPass, map, path } from 'ramda'
+import { anyPass, map, mergeDeepRight, path } from 'ramda'
 import { RawData, WebSocket } from 'ws'
 import cluster from 'cluster'
 import { randomUUID } from 'crypto'
 
 import { createRelayedEventMessage, createSubscriptionMessage } from '../utils/messages'
-import { isEventIdValid, isEventMatchingFilter, isEventSignatureValid } from '../utils/event'
-import { Mirror, Settings } from '../@types/settings'
+import { EventLimits, FeeSchedule, Mirror, Settings } from '../@types/settings'
+import { getEventExpiration, getEventProofOfWork, getPubkeyProofOfWork, getPublicKey, getRelayPrivateKey, isEventIdValid, isEventKindOrRangeMatch, isEventMatchingFilter, isEventSignatureValid, isExpiredEvent } from '../utils/event'
+import { IEventRepository, IUserRepository } from '../@types/repositories'
 import { createLogger } from '../factories/logger-factory'
+import { Event } from '../@types/event'
+import { EventExpirationTimeMetadataKey } from '../constants/base'
 import { IRunnable } from '../@types/base'
 import { OutgoingEventMessage } from '../@types/messages'
 import { RelayedEvent } from '../@types/event'
@@ -19,6 +22,8 @@ export class StaticMirroringWorker implements IRunnable {
   private config: Mirror
 
   public constructor(
+    private readonly eventRepository: IEventRepository,
+    private readonly userRepository: IUserRepository,
     private readonly process: NodeJS.Process,
     private readonly settings: () => Settings,
   ) {
@@ -57,7 +62,7 @@ export class StaticMirroringWorker implements IRunnable {
             this.send(JSON.stringify(createSubscriptionMessage(subscriptionId, filters)))
           }
         })
-        .on('message', async function (raw: RawData) {
+        .on('message', async (raw: RawData) => {
           try {
             const message = JSON.parse(raw.toString('utf8')) as OutgoingEventMessage
 
@@ -70,7 +75,7 @@ export class StaticMirroringWorker implements IRunnable {
               return
             }
 
-            const event = message[2]
+            let event = message[2]
 
             if (!anyPass(map(isEventMatchingFilter, config.filters))(event)) {
               return
@@ -80,10 +85,34 @@ export class StaticMirroringWorker implements IRunnable {
               return
             }
 
+            if (isExpiredEvent(event)) {
+              return
+            }
+
+            const eventExpiration = getEventExpiration(event)
+            if (eventExpiration) {
+              event = {
+                ...event,
+                [EventExpirationTimeMetadataKey]: eventExpiration,
+              } as any
+            }
+
+            if (!this.canAcceptEvent(event)) {
+              return
+            }
+
+            if (!await this.isUserAdmitted(event)) {
+              return
+            }
+
             since = Math.floor(Date.now() / 1000) - 30
 
-            if (cluster.isWorker && typeof process.send === 'function') {
-              debug('%s >> local: %s', config.address, event.id)
+            debug('%s >> local: %s', config.address, event.id)
+
+            const inserted = await this.eventRepository.create(event)
+
+            if (inserted && cluster.isWorker && typeof process.send === 'function') {
+
               process.send({
                 eventName: WebSocketServerAdapterEvent.Broadcast,
                 event,
@@ -108,6 +137,161 @@ export class StaticMirroringWorker implements IRunnable {
     }
 
     this.client = createMirror(this.config)
+  }
+
+  private getRelayPublicKey(): string {
+    const relayPrivkey = getRelayPrivateKey(this.settings().info.relay_url)
+    return getPublicKey(relayPrivkey)
+  }
+
+  private canAcceptEvent(event: Event): boolean {
+    if (this.getRelayPublicKey() === event.pubkey) {
+      debug(`event ${event.id} not accepted: pubkey is relay pubkey`)
+      return false
+    }
+
+    const now = Math.floor(Date.now() / 1000)
+
+    const eventLimits = this.settings().limits?.event ?? {}
+
+    const eventLimitOverrides = this.config.limits.event ?? {}
+
+    const limits = mergeDeepRight(eventLimits, eventLimitOverrides) as EventLimits
+
+    if (Array.isArray(limits.content)) {
+      for (const limit of limits.content) {
+        if (
+          typeof limit.maxLength !== 'undefined'
+          && limit.maxLength > 0
+          && event.content.length > limit.maxLength
+          && (
+            !Array.isArray(limit.kinds)
+            || limit.kinds.some(isEventKindOrRangeMatch(event))
+          )
+        ) {
+          debug(`event ${event.id} not accepted: content is longer than ${limit.maxLength} bytes`)
+          return false
+        }
+      }
+    } else if (
+      typeof limits.content?.maxLength !== 'undefined'
+      && limits.content?.maxLength > 0
+      && event.content.length > limits.content.maxLength
+      && (
+        !Array.isArray(limits.content.kinds)
+        || limits.content.kinds.some(isEventKindOrRangeMatch(event))
+      )
+    ) {
+      debug(`event ${event.id} not accepted: content is longer than ${limits.content.maxLength} bytes`)
+      return false
+    }
+
+    if (
+      typeof limits.createdAt?.maxPositiveDelta !== 'undefined'
+      && limits.createdAt.maxPositiveDelta > 0
+      && event.created_at > now + limits.createdAt.maxPositiveDelta) {
+      debug(`event ${event.id} not accepted: created_at is more than ${limits.createdAt.maxPositiveDelta} seconds in the future`)
+      return false
+    }
+
+    if (
+      typeof limits.createdAt?.maxNegativeDelta !== 'undefined'
+      && limits.createdAt.maxNegativeDelta > 0
+      && event.created_at < now - limits.createdAt.maxNegativeDelta) {
+      debug(`event ${event.id} not accepted: created_at is more than ${limits.createdAt.maxNegativeDelta} seconds in the past`)
+      return false
+    }
+
+    if (
+      typeof limits.eventId?.minLeadingZeroBits !== 'undefined'
+      && limits.eventId.minLeadingZeroBits > 0
+    ) {
+      const pow = getEventProofOfWork(event.id)
+      if (pow < limits.eventId.minLeadingZeroBits) {
+        debug(`event ${event.id} not accepted: pow difficulty ${pow}<${limits.eventId.minLeadingZeroBits}`)
+        return false
+      }
+    }
+
+    if (
+      typeof limits.pubkey?.minLeadingZeroBits !== 'undefined'
+      && limits.pubkey.minLeadingZeroBits > 0
+    ) {
+      const pow = getPubkeyProofOfWork(event.pubkey)
+      if (pow < limits.pubkey.minLeadingZeroBits) {
+        debug(`event ${event.id} not accepted: pow pubkey difficulty ${pow}<${limits.pubkey.minLeadingZeroBits}`)
+        return false
+      }
+    }
+
+    if (
+      typeof limits.pubkey?.whitelist !== 'undefined'
+      && limits.pubkey.whitelist.length > 0
+      && !limits.pubkey.whitelist.some((prefix) => event.pubkey.startsWith(prefix))
+    ) {
+      debug(`event ${event.id} not accepted: pubkey not allowed: ${event.pubkey}`)
+      return false
+    }
+
+    if (
+      typeof limits.pubkey?.blacklist !== 'undefined'
+      && limits.pubkey.blacklist.length > 0
+      && limits.pubkey.blacklist.some((prefix) => event.pubkey.startsWith(prefix))
+    ) {
+      debug(`event ${event.id} not accepted: pubkey not allowed: ${event.pubkey}`)
+      return false
+    }
+
+    if (
+      typeof limits.kind?.whitelist !== 'undefined'
+      && limits.kind.whitelist.length > 0
+      && !limits.kind.whitelist.some(isEventKindOrRangeMatch(event))) {
+      debug(`blocked: event kind ${event.kind} not allowed`)
+      return false
+    }
+
+    if (
+      typeof limits.kind?.blacklist !== 'undefined'
+      && limits.kind.blacklist.length > 0
+      && limits.kind.blacklist.some(isEventKindOrRangeMatch(event))) {
+      debug(`blocked: event kind ${event.kind} not allowed`)
+      return false
+    }
+
+    return true
+  }
+
+  protected async isUserAdmitted(event: Event): Promise<boolean> {
+    const currentSettings = this.settings()
+
+    if (currentSettings.payments?.enabled !== true) {
+      return true
+    }
+
+    const isApplicableFee = (feeSchedule: FeeSchedule) =>
+      feeSchedule.enabled
+      && !feeSchedule.whitelists?.pubkeys?.some((prefix) => event.pubkey.startsWith(prefix))
+      && !feeSchedule.whitelists?.event_kinds?.some(isEventKindOrRangeMatch(event))
+
+    const feeSchedules = currentSettings.payments?.feeSchedules?.admission?.filter(isApplicableFee)
+
+    if (!Array.isArray(feeSchedules) || !feeSchedules.length) {
+      return true
+    }
+
+    const user = await this.userRepository.findByPubkey(event.pubkey)
+    if (user?.isAdmitted !== true) {
+      debug(`user not admitted: ${event.pubkey}`)
+      return false
+    }
+
+    const minBalance = currentSettings.limits?.event?.pubkey?.minBalance
+    if (minBalance && user.balance < minBalance) {
+      debug(`user not admitted: user balance ${user.balance} < ${minBalance}`)
+      return false
+    }
+
+    return true
   }
 
   private onMessage(message: { eventName: string, event: unknown, source: string }): void {

--- a/src/factories/static-mirroring.worker-factory.ts
+++ b/src/factories/static-mirroring.worker-factory.ts
@@ -1,6 +1,19 @@
+import { getMasterDbClient, getReadReplicaDbClient } from '../database/client'
 import { createSettings } from './settings-factory'
+import { EventRepository } from '../repositories/event-repository'
 import { StaticMirroringWorker } from '../app/static-mirroring-worker'
+import { UserRepository } from '../repositories/user-repository'
 
 export const staticMirroringWorkerFactory = () => {
-  return new StaticMirroringWorker(process, createSettings)
+  const dbClient = getMasterDbClient()
+  const readReplicaDbClient = getReadReplicaDbClient()
+  const eventRepository = new EventRepository(dbClient, readReplicaDbClient)
+  const userRepository = new UserRepository(dbClient)
+
+  return new StaticMirroringWorker(
+    eventRepository,
+    userRepository,
+    process,
+    createSettings,
+  )
 }

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -125,7 +125,7 @@ export class SettingsStatic {
     const settingsFilePath = join(basePath, `settings.${fileType}`)
 
     const reload = () => {
-      console.log('reloading settings')
+      debug('reloading settings')
       SettingsStatic._settings = undefined
       SettingsStatic.createSettings()
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Incoming events from mirrored relays are now saved. 
It is possible to configure event limit overrides for each mirror, so that for example, mirrored events do not need to be from paid users.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
No related issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Mirroring was not saving events to the database, just merely rebroadcasting it to connected clients which made mirroring less useful.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Manually tested

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Non-functional change (docs, style, minor refactor)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my code changes.
- [x] All new and existing tests passed.
