### PR TITLE
fix git clone instruction on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ You may have to uninstall Docker if you installed it using a different guide.
 
 Clone repository and enter directory:
   ```
-  git clone git@github.com:Cameri/nostream.git
+  git clone https://github.com/cameri/nostream.git
   cd nostream
   ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed the `git clone` instruction in the README file.  
Replaced the SSH-based URL with the HTTPS-based URL to make it more accessible for users who haven't set up SSH keys.

## Related Issue
No related issue was open at the time of this fix.

## Motivation and Context
Using the SSH URL (`git@github.com`) can cause confusion or errors for users who haven't configured their SSH keys with GitHub. Switching to the HTTPS version improves accessibility and ease of use for a broader audience, especially new contributors.

## How Has This Been Tested?
Visually confirmed the updated README renders correctly and that the new `git clone https://github.com/cameri/nostream.git` command works as expected from a clean environment.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Non-functional change (docs, style, minor refactor)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my code changes.
- [x] All new and existing tests passed.
