### PR TITLE
fix: set event_deduplication in seed script

### DIFF
--- a/seeds/0000-events.js
+++ b/seeds/0000-events.js
@@ -1,6 +1,32 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 const NAMESPACE = 'c646b451-db73-47fb-9a70-ea24ce8a225a'
+
+function isReplaceableEvent(kind) {
+  return kind === 0
+    || kind === 3
+    || kind === 41
+    || (kind >= 10000 && kind < 20000)
+}
+
+function isParameterizedReplaceableEvent(kind) {
+  return kind >= 30000 && kind < 40000
+}
+
+function getEventDeduplication(event) {
+  if (isReplaceableEvent(event.kind)) {
+    return JSON.stringify([event.pubkey, event.kind])
+  }
+
+  if (isParameterizedReplaceableEvent(event.kind)) {
+    const dTag = event.tags.find((tag) => tag.length >= 2 && tag[0] === 'd')
+    const [, ...deduplication] = dTag ?? [null, '']
+    return JSON.stringify(deduplication)
+  }
+
+  return null
+}
+
 exports.seed = async function (knex) {
   await knex('events').del()
 
@@ -16,6 +42,7 @@ exports.seed = async function (knex) {
       event_content: event.content,
       event_tags: JSON.stringify(event.tags),
       event_signature: Buffer.from(event.sig, 'hex'),
+      event_deduplication: getEventDeduplication(event),
     })
 
     return result


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Seed script wasn't setting event_deduplication. Added a helper to compute it the same way ```upsert()``` does``` [pubkey, kind] ```for replaceable events, d tag values for parameterized replaceable ones.
event_delegator is no longer handled since it was removed in migration 20240111204900.

Fixes #135 

## Motivation and Context
Seeded events should match the same state as events inserted through the relay at runtime. Without ```event_deduplication```, the unique index on replaceable events doesn't work correctly for seeded data.

## How Has This Been Tested?
* Verified the deduplication logic matches EventRepository.upsert() and ParameterizedReplaceableEventStrategy
* Confirmed no duplicate dedup keys among seed data


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Non-functional change (docs, style, minor refactor)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my code changes.
- [x] All new and existing tests passed.
