### PR TITLE
docs: add Linux DNS troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,60 @@ The logs can be viewed with:
   journalctl -u nostream
   ```
 
+## Troubleshooting
+
+### Linux: Docker DNS resolution failures (`EAI_AGAIN`)
+
+On some Linux environments (especially rolling-release distros or setups using
+`systemd-resolved`), `docker compose` builds can fail with DNS errors such as:
+
+- `getaddrinfo EAI_AGAIN registry.npmjs.org`
+- `Temporary failure in name resolution`
+
+To fix this, configure Docker daemon DNS in `/etc/docker/daemon.json`.
+
+1. Create or update `/etc/docker/daemon.json`:
+
+  ```
+  sudo mkdir -p /etc/docker
+  sudo nano /etc/docker/daemon.json
+  ```
+
+  Add or update the file with:
+
+  ```
+  {
+    "dns": ["1.1.1.1", "8.8.8.8"]
+  }
+  ```
+
+  If this file already exists, merge the `dns` key into the existing JSON
+  instead of replacing the entire file.
+
+  If your environment does not allow public resolvers, replace `1.1.1.1` and
+  `8.8.8.8` with DNS servers approved by your network.
+
+2. Restart Docker:
+
+  ```
+  sudo systemctl restart docker
+  ```
+
+3. Verify DNS works inside containers:
+
+  ```
+  docker run --rm busybox nslookup registry.npmjs.org
+  ```
+
+4. Retry starting nostream:
+
+  ```
+  ./scripts/start
+  ```
+
+Note: avoid `127.0.0.53` in Docker DNS settings because it points to the host's
+local resolver stub and is often unreachable from containers.
+
 ## Quick Start (Standalone)
 
 Set the following environment variables:


### PR DESCRIPTION
## Description
Added a Linux-specific troubleshooting section to README for Docker DNS resolution failures during `docker compose` builds.

The new section includes:
- Symptoms (`EAI_AGAIN`, temporary name resolution failures)
- Docker daemon DNS configuration in `/etc/docker/daemon.json`
- Docker restart step
- Verification command inside a container
- Notes for `systemd-resolved` (`127.0.0.53`) and restricted network environments

## Related Issue
Closes #396

## Context
Some Linux setups (especially with `systemd-resolved` or rolling-release distributions) can fail DNS resolution during image builds. This blocks local onboarding and forces users into ad-hoc workarounds. Adding clear troubleshooting steps in README provides a standard and portable fix path.

## How Has This Been Tested?
- Verified the README section placement and markdown formatting.
- Verified the documented commands are syntactically correct and actionable on Linux Docker setups.
- Confirmed scope is documentation-only (no runtime or source code changes).

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Non-functional change (docs, style, minor refactor)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my code changes.
- [ ] All new and existing tests passed.
