### PR TITLE
fix(router): NIP-11 being served only on root instead of relay path

### DIFF
--- a/src/handlers/request-handlers/root-request-handler.ts
+++ b/src/handlers/request-handlers/root-request-handler.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from 'express'
+import accepts from 'accepts'
 import { path } from 'ramda'
 
 import { createSettings } from '../../factories/settings-factory'
@@ -9,7 +10,7 @@ import packageJson from '../../../package.json'
 export const rootRequestHandler = (request: Request, response: Response, next: NextFunction) => {
   const settings = createSettings()
 
-  if (request.header('accept')?.includes('application/nostr+json')) {
+  if (accepts(request).type(['application/nostr+json'])) {
     const {
       info: { name, description, pubkey: rawPubkey, contact, relay_url },
     } = settings

--- a/src/handlers/request-handlers/root-request-handler.ts
+++ b/src/handlers/request-handlers/root-request-handler.ts
@@ -9,7 +9,7 @@ import packageJson from '../../../package.json'
 export const rootRequestHandler = (request: Request, response: Response, next: NextFunction) => {
   const settings = createSettings()
 
-  if (request.header('accept') === 'application/nostr+json') {
+  if (request.header('accept')?.includes('application/nostr+json')) {
     const {
       info: { name, description, pubkey: rawPubkey, contact, relay_url },
     } = settings

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,5 +1,5 @@
-import express from 'express'
 import accepts from 'accepts'
+import express from 'express'
 
 import { nodeinfo21Handler, nodeinfoHandler } from '../handlers/request-handlers/nodeinfo-handler'
 import admissionRouter from './admissions'

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,4 +1,5 @@
 import express from 'express'
+import accepts from 'accepts'
 
 import { nodeinfo21Handler, nodeinfoHandler } from '../handlers/request-handlers/nodeinfo-handler'
 import admissionRouter from './admissions'
@@ -12,7 +13,7 @@ import { rootRequestHandler } from '../handlers/request-handlers/root-request-ha
 const router = express.Router()
 
 router.use((req, res, next) => {
-  if (req.method === 'GET' && req.headers.accept?.includes('application/nostr+json')) {
+  if (req.method === 'GET' && accepts(req).type(['application/nostr+json'])) {
     return rootRequestHandler(req, res, next)
   }
   next()

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -11,6 +11,13 @@ import { rootRequestHandler } from '../handlers/request-handlers/root-request-ha
 
 const router = express.Router()
 
+router.use((req, res, next) => {
+  if (req.method === 'GET' && req.headers.accept?.includes('application/nostr+json')) {
+    return rootRequestHandler(req, res, next)
+  }
+  next()
+})
+
 router.get('/', rootRequestHandler)
 router.get('/healthz', getHealthRequestHandler)
 router.get('/terms', getTermsRequestHandler)


### PR DESCRIPTION
## Description
This PR fixes an issue where the NIP-11 relay information document was only being served at the root (`/`) of the domain, even when the relay itself was configured on a different path (for example `/v1`). 

Specifically, this PR introduces the following changes:
* Adds a top-level request interceptor that checks for `Accept: application/nostr+json`.
* Routes matching requests to the NIP-11 handler regardless of the path.
* Updates the NIP-11 handler to use flexible header matching (`includes` instead of strict equality).
* Normalizes header checks to avoid issues with compound or case variations.

## Related Issue
#381 

## Motivation and Context
According to the NIP-11 spec, the relay metadata should be available on the same URI that handles the WebSocket connection. In practice, this means a relay at `wss://domain.com/v1` should expose its NIP-11 document at `https://domain.com/v1`, not just at `https://domain.com/`.

Previously, WebSocket upgrades in Nostream were effectively path-agnostic, while Express routes were explicitly bound to `/`. As a result, requests like `GET /v1` with `Accept: application/nostr+json` returned a `404` instead of the expected NIP-11 response. This change keeps the fix minimal while aligning behavior more closely with the NIP-11 spec and how relays are typically exposed behind proxies or path prefixes.

## How Has This Been Tested?
Tested locally by verifying that NIP-11 is now correctly served on the relay path (e.g., `/v1`). Verified that the existing behavior on the root (`/`) remains unchanged and that the updated handler successfully processes requests from real-world clients sending compound Accept headers.

**Test run:**
```bash
curl -H "Accept: application/nostr+json" http://localhost:8008/v1
```

## Types of changes
- [ ] Non-functional change (docs, style, minor refactor)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my code changes.
- [ ] All new and existing tests passed.