### PR TITLE
Added expires_at filter in message pipeline

### DIFF
--- a/src/handlers/subscribe-message-handler.ts
+++ b/src/handlers/subscribe-message-handler.ts
@@ -4,7 +4,7 @@ import { pipeline } from 'stream/promises'
 
 import { createEndOfStoredEventsNoticeMessage, createNoticeMessage, createOutgoingEventMessage } from '../utils/messages'
 import { IAbortable, IMessageHandler } from '../@types/message-handlers'
-import { isEventMatchingFilter, toNostrEvent } from '../utils/event'
+import { isEventMatchingFilter, isExpiredEvent, toNostrEvent } from '../utils/event'
 import { streamEach, streamEnd, streamFilter, streamMap } from '../utils/stream'
 import { SubscriptionFilter, SubscriptionId } from '../@types/subscription'
 import { createLogger } from '../factories/logger-factory'
@@ -55,6 +55,12 @@ export class SubscribeMessageHandler implements IMessageHandler, IAbortable {
     const sendEOSE = () =>
       this.webSocket.emit(WebSocketAdapterEvent.Message, createEndOfStoredEventsNoticeMessage(subscriptionId))
     const isSubscribedToEvent = SubscribeMessageHandler.isClientSubscribedToEvent(filters)
+    const isNotExpired = (event: Event)=>{
+      if (isExpiredEvent(event)) {
+        return false
+      }
+      return true
+  }
 
     const findEvents = this.eventRepository.findByFilters(filters).stream()
 
@@ -65,6 +71,7 @@ export class SubscribeMessageHandler implements IMessageHandler, IAbortable {
         findEvents,
         streamFilter(propSatisfies(isNil, 'deleted_at')),
         streamMap(toNostrEvent),
+        streamFilter(isNotExpired),
         streamFilter(isSubscribedToEvent),
         streamEach(sendEvent),
         streamEnd(sendEOSE),
@@ -117,3 +124,4 @@ export class SubscribeMessageHandler implements IMessageHandler, IAbortable {
 
   }
 }
+

--- a/test/unit/handlers/subscribe-message-handler.spec.ts
+++ b/test/unit/handlers/subscribe-message-handler.spec.ts
@@ -3,6 +3,7 @@ import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import EventEmitter from 'events'
 import Sinon from 'sinon'
+import sinonChai from 'sinon-chai'
 
 import { IAbortable, IMessageHandler } from '../../../src/@types/message-handlers'
 import { MessageType, SubscribeMessage } from '../../../src/@types/messages'
@@ -14,10 +15,14 @@ import { PassThrough } from 'stream'
 import { SubscribeMessageHandler } from '../../../src/handlers/subscribe-message-handler'
 import { WebSocketAdapterEvent } from '../../../src/constants/adapter'
 
+chai.use(sinonChai)
 chai.use(chaiAsPromised)
 const { expect } = chai
 
-const toDbEvent = (event: Event) => ({
+const toDbEvent = (
+  event: Event,
+  metadata: { expires_at?: number, deleted_at?: Date | null } = {},
+) => ({
   event_id: Buffer.from(event.id, 'hex'),
   event_kind: event.kind,
   event_pubkey: Buffer.from(event.pubkey, 'hex'),
@@ -25,6 +30,7 @@ const toDbEvent = (event: Event) => ({
   event_content: event.content,
   event_tags: event.tags,
   event_signature: Buffer.from(event.sig, 'hex'),
+  ...metadata,
 })
 
 describe('SubscribeMessageHandler', () => {
@@ -112,11 +118,13 @@ describe('SubscribeMessageHandler', () => {
 
   describe('#fetchAndSend', () => {
     let event: Event
+    let clock: Sinon.SinonFakeTimers
     let webSocketOnMessageStub: Sinon.SinonStub
     let webSocketOnSubscribeStub: Sinon.SinonStub
     let isClientSubscribedToEventStub: Sinon.SinonStub
 
     beforeEach(() => {
+      clock = Sinon.useFakeTimers(1665546189000)
       event = {
         'id': 'b1601d26958e6508b7b9df0af609c652346c09392b6534d93aead9819a51b4ef',
         'pubkey': '22e804d26ed16b68db5259e78449e96dab5d464c8f470bda3eb1a70467f2c793',
@@ -134,6 +142,10 @@ describe('SubscribeMessageHandler', () => {
       webSocket.on(WebSocketAdapterEvent.Message, webSocketOnMessageStub)
       webSocket.on(WebSocketAdapterEvent.Subscribe, webSocketOnSubscribeStub)
       //streamEndSpy = sandbox.spy(Stream, '_end' as any)
+    })
+
+    afterEach(() => {
+      clock.restore()
     })
 
     it('does not send event if client is not subscribed to it', async () => {
@@ -162,6 +174,53 @@ describe('SubscribeMessageHandler', () => {
       expect(eventRepositoryFindByFiltersStub).to.have.been.calledOnceWithExactly(filters)
       expect(webSocketOnMessageStub).to.have.been.calledWithExactly(
         ['EVENT', subscriptionId, event],
+      )
+    })
+
+    it('does not send expired events', async () => {
+      isClientSubscribedToEventStub.returns(always(true))
+
+      const now = Math.floor(clock.now / 1000)
+      const promise = (handler as any).fetchAndSend(subscriptionId, filters)
+
+      const expiredEvent: Event = {
+        ...event,
+        tags: [['expiration', String(now - 1)] as any],
+      }
+
+      stream.write(toDbEvent(expiredEvent))
+      stream.end()
+
+      await promise
+
+      expect(eventRepositoryFindByFiltersStub).to.have.been.calledOnceWithExactly(filters)
+      expect(webSocketOnMessageStub).to.have.been.calledOnceWithExactly(
+        ['EOSE', subscriptionId],
+      )
+    })
+
+    it('sends event if expiration is in the future', async () => {
+      isClientSubscribedToEventStub.returns(always(true))
+
+      const now = Math.floor(clock.now / 1000)
+      const promise = (handler as any).fetchAndSend(subscriptionId, filters)
+
+      const eventWithFutureExpiration: Event = {
+        ...event,
+        tags: [['expiration', String(now + 60)] as any],
+      }
+
+      stream.write(toDbEvent(eventWithFutureExpiration))
+      stream.end()
+
+      await promise
+
+      expect(eventRepositoryFindByFiltersStub).to.have.been.calledOnceWithExactly(filters)
+      expect(webSocketOnMessageStub).to.have.been.calledWithExactly(
+        ['EVENT', subscriptionId, eventWithFutureExpiration],
+      )
+      expect(webSocketOnMessageStub).to.have.been.calledWithExactly(
+        ['EOSE', subscriptionId],
       )
     })
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR adds an expires_at filter in the message pipeline. This ensures that the events that are expired will not be given to the users

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#401 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Earlier, only the deleted_At filter was used in the message pipeline. This made users get expired events also. This poses a problem, especially in gift-wrapped events.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Both manual and unit testing have been performed. A relay server was spun up, and messages with the expires_At field were sent and then retrieved after expiry time. The behaviour matched the expected behaviour. All the older tests, EsLint checks and new tests were run and tested.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Non-functional change (docs, style, minor refactor)
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ x I have added tests to cover my code changes.
- [ x] All new and existing tests passed.
