### PR TITLE
fix: update Dockerfile to run database migrations in CMD

### DIFF
--- a/Dockerfile.railwayapp
+++ b/Dockerfile.railwayapp
@@ -23,8 +23,6 @@ ADD migrations /build/migrations
 
 RUN npm install -g knex@2.4.0 && npm install --quiet
 
-RUN npm run db:migrate
-
 COPY . .
 
 RUN npm run build
@@ -79,4 +77,4 @@ USER 1000:1000
 
 RUN mkdir -p $NOSTR_CONFIG_DIR
 
-CMD ["node", "src/index.js"]
+CMD ["sh", "-c", "npm run db:migrate && node src/index.js"]

--- a/Dockerfile.railwayapp
+++ b/Dockerfile.railwayapp
@@ -29,6 +29,9 @@ RUN npm run build
 
 FROM node:24-alpine
 
+# Install dumb-init for proper signal handling
+RUN apk add --no-cache dumb-init
+
 ARG PORT
 ARG PGHOST
 ARG PGPORT
@@ -69,12 +72,19 @@ LABEL org.opencontainers.image.licenses=MIT
 
 WORKDIR /app
 
+# Copy runtime artifacts and configuration
 COPY --from=build /build/dist .
+COPY --from=build /build/package.json /build/package-lock.json ./
+COPY --from=build /build/knexfile.js ./
+COPY --from=build /build/migrations ./migrations
+COPY --from=build /build/seeds ./seeds
 
-RUN npm install --omit=dev --quiet
+RUN npm install --omit=dev --quiet && npm install -g knex@2.4.0
 
 USER 1000:1000
 
 RUN mkdir -p $NOSTR_CONFIG_DIR
+
+ENTRYPOINT ["dumb-init", "--"]
 
 CMD ["sh", "-c", "npm run db:migrate && node src/index.js"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes the Railway deployment failure caused by running database migrations during the Docker build phase when the PostgreSQL service isn't available.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes #379 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```bash
docker build -f Dockerfile.railwayapp \
  --build-arg PORT=8080 \
  --build-arg PGHOST=localhost \
  --build-arg PGPORT=5432 \
  --build-arg PGDATABASE=nostream \
  --build-arg PGUSER=postgres \
  --build-arg PGPASSWORD=postgres \
  -t nostream:test .
```
Build completed successfully with no ECONNREFUSED errors


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Non-functional change (docs, style, minor refactor)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my code changes.
- [ ] All new and existing tests passed.
