### PR TITLE
resolve typescript buffer-to-uint8array type mismatches

### DIFF
--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -103,7 +103,7 @@ export const isEventMatchingFilter = (filter: SubscriptionFilter) => (event: Eve
 }
 
 export const getEventHash = async (event: Event | UnidentifiedEvent | UnsignedEvent): Promise<string> => {
-  const id = await secp256k1.utils.sha256(Buffer.from(JSON.stringify(serializeEvent(event))))
+  const id = await secp256k1.utils.sha256(new Uint8Array(Buffer.from(JSON.stringify(serializeEvent(event)))))
 
   return Buffer.from(id).toString('hex')
 }
@@ -160,7 +160,7 @@ export const encryptKind4Event = (
   receiverPubkey: Pubkey,
 ) => (event: UnsignedEvent): UnsignedEvent => {
   const key = secp256k1
-    .getSharedSecret(senderPrivkey, `02${receiverPubkey}`, true)
+    .getSharedSecret(typeof senderPrivkey === 'string' ? senderPrivkey : new Uint8Array(senderPrivkey), `02${receiverPubkey}`, true)
     .subarray(1)
 
   const iv = getRandomValues(new Uint8Array(16))
@@ -168,7 +168,7 @@ export const encryptKind4Event = (
   // deepcode ignore InsecureCipherNoIntegrity: NIP-04 Encrypted Direct Message uses aes-256-cbc
   const cipher = createCipheriv(
     'aes-256-cbc',
-    Buffer.from(key),
+    new Uint8Array(key),
     iv,
   )
 


### PR DESCRIPTION
### Description
This PR resolves three TypeScript compilation errors in `src/utils/event.ts` caused by incompatibility between `Buffer` and the stricter `Uint8Array<ArrayBuffer>` requirements in modern TypeScript environments.

The fix explicitly wraps `Buffer` instances using `new Uint8Array()` or introduces type-safe checks to ensure compatibility with cryptographic functions used by **noble-secp256k1** and Node.js `crypto` APIs.

---

### Related Issue
Fixes #444 

---

### Motivation and Context
Modern TypeScript definitions enforce stricter typing for `Uint8Array`, often requiring a strict `ArrayBuffer` backing. Although Node.js `Buffer` extends `Uint8Array`, it internally relies on `ArrayBufferLike` (which may include `SharedArrayBuffer`), leading to **"is not assignable"** errors under strict type checking.

This change ensures:
- Full TypeScript compatibility
- Type safety in cryptographic operations
- Successful project compilation in newer TypeScript and Node.js environments

---

### How Has This Been Tested?
- Verified that the TypeScript compiler no longer reports errors in `src/utils/event.ts`
- Confirmed no runtime behavior changes

---

### Screenshots (if appropriate)
N/A

---

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

### Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the CONTRIBUTING document
- [ ] I have added tests to cover my code changes
- [x] All new and existing tests passed