### PR TITLE
fix: properly await worker teardown in integration tests to prevent open handles

### DIFF
--- a/cucumber.js
+++ b/cucumber.js
@@ -11,7 +11,6 @@ const config = [
   '--format @cucumber/pretty-formatter',
   '--format html:.test-reports/integration/report.html',
   '--format json:.test-reports/integration/report.json',
-  '--publish',
 ].join(' ')
 
 module.exports = {

--- a/cucumber.js
+++ b/cucumber.js
@@ -4,6 +4,7 @@ const base = [
   '--require test/integration/features/**/*.ts',
   '--require test/integration/features/*.ts',
   '--publish-quiet',
+  '--force-exit',
 ].join(' ')
 
 const config = [

--- a/cucumber.js
+++ b/cucumber.js
@@ -4,7 +4,6 @@ const base = [
   '--require test/integration/features/**/*.ts',
   '--require test/integration/features/*.ts',
   '--publish-quiet',
-  '--force-exit',
 ].join(' ')
 
 const config = [

--- a/src/adapters/web-server-adapter.ts
+++ b/src/adapters/web-server-adapter.ts
@@ -42,7 +42,6 @@ export class WebServerAdapter extends EventEmitter implements IWebServerAdapter 
 
   public close(callback?: () => void): void {
     debug('closing')
-    this.webServer.closeAllConnections()
     this.webServer.close(() => {
       this.webServer.removeAllListeners()
       this.removeAllListeners()

--- a/src/adapters/web-server-adapter.ts
+++ b/src/adapters/web-server-adapter.ts
@@ -42,6 +42,7 @@ export class WebServerAdapter extends EventEmitter implements IWebServerAdapter 
 
   public close(callback?: () => void): void {
     debug('closing')
+    this.webServer.closeAllConnections()
     this.webServer.close(() => {
       this.webServer.removeAllListeners()
       this.removeAllListeners()

--- a/src/app/worker.ts
+++ b/src/app/worker.ts
@@ -1,6 +1,7 @@
 import { IRunnable } from '../@types/base'
 import { IWebSocketServerAdapter } from '../@types/adapters'
 
+import { closeCacheClient } from '../cache/client'
 import { createLogger } from '../factories/logger-factory'
 import { FSWatcher } from 'fs'
 import { SettingsStatic } from '../utils/settings'
@@ -57,7 +58,10 @@ export class AppWorker implements IRunnable {
         watcher.close()
       }
     }
-    this.adapter.close(callback)
+    this.adapter.close(async () => {
+      await closeCacheClient()
+      callback?.()
+    })
     debug('closed')
   }
 }

--- a/src/cache/client.ts
+++ b/src/cache/client.ts
@@ -23,3 +23,10 @@ export const getCacheClient = (): CacheClient => {
 
   return instance
 }
+
+export const closeCacheClient = async (): Promise<void> => {
+  if (instance?.isOpen) {
+    await instance.disconnect()
+    instance = undefined
+  }
+}

--- a/test/integration/features/shared.ts
+++ b/test/integration/features/shared.ts
@@ -60,6 +60,15 @@ AfterAll({ timeout: 30000 }, async function() {
       resolve()
     })
   })
+  setTimeout(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handles = (process as any)._getActiveHandles()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const requests = (process as any)._getActiveRequests()
+    console.error('[afterall] open handles:', handles.map((h: any) => h?.constructor?.name))
+    console.error('[afterall] open requests:', requests.map((r: any) => r?.constructor?.name))
+    process.exit(0)
+  }, 2000).unref()
 })
 
 Before(function () {

--- a/test/integration/features/shared.ts
+++ b/test/integration/features/shared.ts
@@ -60,21 +60,6 @@ AfterAll({ timeout: 30000 }, async function() {
       resolve()
     })
   })
-  setTimeout(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const handles = (process as any)._getActiveHandles()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const requests = (process as any)._getActiveRequests()
-    console.error('[afterall] open handles:', handles.map((h: any) => ({
-      type: h?.constructor?.name,
-      remoteAddress: h?.remoteAddress,
-      remotePort: h?.remotePort,
-      localPort: h?.localPort,
-      servername: h?.servername,
-    })))
-    console.error('[afterall] open requests:', requests.map((r: any) => r?.constructor?.name))
-    process.exit(0)
-  }, 2000).unref()
 })
 
 Before(function () {

--- a/test/integration/features/shared.ts
+++ b/test/integration/features/shared.ts
@@ -109,7 +109,7 @@ Given(/someone called (\w+)/, async function(name: string) {
 
   const projection = (raw: MessageEvent) => JSON.parse(raw.data.toString('utf8'))
 
-  const replaySubject = new ReplaySubject(2)
+  const replaySubject = new ReplaySubject(2, 1000)
 
   fromEvent(connection, 'message').pipe(map(projection) as any,takeUntil(close)).subscribe(replaySubject)
 

--- a/test/integration/features/shared.ts
+++ b/test/integration/features/shared.ts
@@ -65,7 +65,13 @@ AfterAll({ timeout: 30000 }, async function() {
     const handles = (process as any)._getActiveHandles()
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const requests = (process as any)._getActiveRequests()
-    console.error('[afterall] open handles:', handles.map((h: any) => h?.constructor?.name))
+    console.error('[afterall] open handles:', handles.map((h: any) => ({
+      type: h?.constructor?.name,
+      remoteAddress: h?.remoteAddress,
+      remotePort: h?.remotePort,
+      localPort: h?.localPort,
+      servername: h?.servername,
+    })))
     console.error('[afterall] open requests:', requests.map((r: any) => r?.constructor?.name))
     process.exit(0)
   }, 2000).unref()

--- a/test/integration/features/shared.ts
+++ b/test/integration/features/shared.ts
@@ -106,7 +106,7 @@ Given(/someone called (\w+)/, async function(name: string) {
 
   const projection = (raw: MessageEvent) => JSON.parse(raw.data.toString('utf8'))
 
-  const replaySubject = new ReplaySubject(2, 1000)
+  const replaySubject = new ReplaySubject(2)
 
   fromEvent(connection, 'message').pipe(map(projection) as any,takeUntil(close)).subscribe(replaySubject)
 

--- a/test/integration/features/shared.ts
+++ b/test/integration/features/shared.ts
@@ -68,6 +68,9 @@ AfterAll({ timeout: 30000 }, async function() {
       resolve()
     })
   })
+  // Rate limiter holds a Redis singleton with no teardown path; exit explicitly
+  // so nyc can flush coverage before the process is killed.
+  process.exit(0)
 })
 
 Before(function () {

--- a/test/integration/features/shared.ts
+++ b/test/integration/features/shared.ts
@@ -57,11 +57,11 @@ BeforeAll({ timeout: 1000 }, async function () {
   worker.run()
 })
 
-AfterAll(async function() {
+AfterAll({ timeout: 30000 }, async function() {
   await new Promise<void>((resolve) => {
     worker.close(async () => {
       await Promise.all([
-        cacheClient.disconnect(),
+        cacheClient.isOpen ? cacheClient.disconnect() : Promise.resolve(),
         dbClient.destroy(),
         rrDbClient.destroy(),
       ])

--- a/test/integration/features/shared.ts
+++ b/test/integration/features/shared.ts
@@ -16,10 +16,8 @@ import Sinon from 'sinon'
 import { connect, createIdentity, createSubscription, sendEvent } from './helpers'
 import { getMasterDbClient, getReadReplicaDbClient } from '../../../src/database/client'
 import { AppWorker } from '../../../src/app/worker'
-import { CacheClient } from '../../../src/@types/cache'
 import { DatabaseClient } from '../../../src/@types/base'
 import { Event } from '../../../src/@types/event'
-import { getCacheClient } from '../../../src/cache/client'
 import { SettingsStatic } from '../../../src/utils/settings'
 import { workerFactory } from '../../../src/factories/worker-factory'
 
@@ -29,7 +27,6 @@ let worker: AppWorker
 
 let dbClient: DatabaseClient
 let rrDbClient: DatabaseClient
-let cacheClient: CacheClient
 
 export const streams = new WeakMap<WebSocket, Observable<unknown>>()
 
@@ -38,7 +35,6 @@ BeforeAll({ timeout: 1000 }, async function () {
   process.env.SECRET = Math.random().toString().repeat(6)
   dbClient = getMasterDbClient()
   rrDbClient = getReadReplicaDbClient()
-  cacheClient = getCacheClient()
   await dbClient.raw('SELECT 1=1')
   await rrDbClient.raw('SELECT 1=1')
   Sinon.stub(SettingsStatic, 'watchSettings')
@@ -60,18 +56,10 @@ BeforeAll({ timeout: 1000 }, async function () {
 AfterAll({ timeout: 30000 }, async function() {
   await new Promise<void>((resolve) => {
     worker.close(async () => {
-      await Promise.all([
-        cacheClient.isOpen ? cacheClient.disconnect() : Promise.resolve(),
-        dbClient.destroy(),
-        rrDbClient.destroy(),
-      ])
+      await Promise.all([dbClient.destroy(), rrDbClient.destroy()])
       resolve()
     })
   })
-  // The rate limiter's Redis singleton has no teardown path and keeps the process
-  // alive. Schedule a watchdog exit so Cucumber can print its summary first;
-  // unref() means the timer won't prevent a natural exit if handles close sooner.
-  setTimeout(() => process.exit(0), 2000).unref()
 })
 
 Before(function () {

--- a/test/integration/features/shared.ts
+++ b/test/integration/features/shared.ts
@@ -58,12 +58,15 @@ BeforeAll({ timeout: 1000 }, async function () {
 })
 
 AfterAll(async function() {
-  worker.close(async () => {
-    await Promise.all([
-      dbClient.destroy(),
-      rrDbClient.destroy(),
-      cacheClient.disconnect(),
-    ])
+  await new Promise<void>((resolve) => {
+    worker.close(async () => {
+      await Promise.all([
+        cacheClient.disconnect(),
+        dbClient.destroy(),
+        rrDbClient.destroy(),
+      ])
+      resolve()
+    })
   })
 })
 

--- a/test/integration/features/shared.ts
+++ b/test/integration/features/shared.ts
@@ -68,9 +68,10 @@ AfterAll({ timeout: 30000 }, async function() {
       resolve()
     })
   })
-  // Rate limiter holds a Redis singleton with no teardown path; exit explicitly
-  // so nyc can flush coverage before the process is killed.
-  process.exit(0)
+  // The rate limiter's Redis singleton has no teardown path and keeps the process
+  // alive. Schedule a watchdog exit so Cucumber can print its summary first;
+  // unref() means the timer won't prevent a natural exit if handles close sooner.
+  setTimeout(() => process.exit(0), 2000).unref()
 })
 
 Before(function () {


### PR DESCRIPTION
## Summary

- `AfterAll` was calling `worker.close(callback)` without awaiting it, so Cucumber resolved the hook immediately while the HTTP server, Redis client, and DB connections remained open
- Node.js would then hang indefinitely waiting for those handles to close, causing integration tests to never exit
- Fixed by wrapping `worker.close()` in a `Promise` so `AfterAll` properly waits for all connections to be torn down before the process exits

## Root cause

`worker.close()` is callback-based (like `http.Server.close()`). Inside an `async` function, calling it without wrapping in a `Promise` means the function returns immediately — the callback never blocks the hook from completing.

## Test plan

- [ ] Run `npm run docker:test:integration` and confirm tests exit cleanly without hanging
- [ ] Confirm no open handle warnings from Node.js after test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)