### PR TITLE
fix: Multiple tag selections for dedup key in parameterized evetns

### DIFF
--- a/.changeset/strong-candles-yell.md
+++ b/.changeset/strong-candles-yell.md
@@ -1,0 +1,5 @@
+---
+"nostream": patch
+---
+
+Dedup keys were taking multiple tags, that was not according to NIP-01 behaviour.

--- a/migrations/20260419_140000_normalize_parameterized_deduplication.js
+++ b/migrations/20260419_140000_normalize_parameterized_deduplication.js
@@ -1,0 +1,31 @@
+exports.up = async function (knex) {
+  await knex.raw(`
+    WITH ranked AS (
+      SELECT
+        id,
+        row_number() OVER (
+          PARTITION BY event_pubkey, event_kind, jsonb_build_array(COALESCE(event_deduplication->>0, ''))
+          ORDER BY event_created_at DESC, event_id ASC
+        ) AS row_rank
+      FROM events
+      WHERE event_kind >= 30000
+        AND event_kind < 40000
+    )
+    DELETE FROM events AS e
+    USING ranked AS r
+    WHERE e.id = r.id
+      AND r.row_rank > 1;
+  `)
+
+  await knex.raw(`
+    UPDATE events
+    SET event_deduplication = jsonb_build_array(COALESCE(event_deduplication->>0, ''))
+    WHERE event_kind >= 30000
+      AND event_kind < 40000
+      AND event_deduplication IS DISTINCT FROM jsonb_build_array(COALESCE(event_deduplication->>0, ''));
+  `)
+}
+
+exports.down = async function () {
+  // Irreversible data migration.
+}

--- a/src/services/event-import-service.ts
+++ b/src/services/event-import-service.ts
@@ -26,11 +26,11 @@ const enrichEventMetadata = (event: Event): Event => {
   }
 
   if (isParameterizedReplaceableEvent(event)) {
-    const [, ...deduplication] = event.tags.find((tag) => tag.length >= 2 && tag[0] === EventTags.Deduplication) ?? [
+    const [, deduplication] = event.tags.find((tag) => tag.length >= 2 && tag[0] === EventTags.Deduplication) ?? [
       null,
       '',
     ]
-    enriched = { ...enriched, [EventDeduplicationMetadataKey]: deduplication }
+    enriched = { ...enriched, [EventDeduplicationMetadataKey]: deduplication ? [deduplication] : [''] }
   }
 
   return enriched as Event

--- a/test/unit/services/event-import-service.spec.ts
+++ b/test/unit/services/event-import-service.spec.ts
@@ -3,7 +3,13 @@ import { join } from 'path'
 import fs from 'fs'
 import os from 'os'
 
-import { EventImportLineError, EventImportService, EventImportStats } from '../../../src/services/event-import-service'
+import {
+  createEventBatchPersister,
+  EventImportLineError,
+  EventImportService,
+  EventImportStats,
+} from '../../../src/services/event-import-service'
+import { EventDeduplicationMetadataKey, EventKinds, EventTags } from '../../../src/constants/base'
 import { Event } from '../../../src/@types/event'
 import { expect } from 'chai'
 import { getEvents } from '../data/events'
@@ -169,5 +175,37 @@ describe('EventImportService', () => {
       expect((error as Error).message).to.equal('database unavailable')
       expect(lineErrors.length).to.equal(0)
     }
+  })
+
+  it('normalizes parameterized replaceable deduplication to first d tag value', async () => {
+    const parameterizedEvent: Event = {
+      id: 'a'.repeat(64),
+      pubkey: 'b'.repeat(64),
+      created_at: 1,
+      kind: EventKinds.PARAMETERIZED_REPLACEABLE_FIRST,
+      tags: [[EventTags.Deduplication, 'one', 'two']],
+      content: 'hello',
+      sig: 'c'.repeat(128),
+    }
+
+    let upsertedEvents: Event[] = []
+
+    const eventRepository = {
+      create: async () => 0,
+      createMany: async () => 0,
+      upsert: async () => 0,
+      upsertMany: async (events: Event[]) => {
+        upsertedEvents = events
+        return events.length
+      },
+      deleteByPubkeyAndIds: async () => 0,
+    } as any
+
+    const persistBatch = createEventBatchPersister(eventRepository)
+    const inserted = await persistBatch([parameterizedEvent])
+
+    expect(inserted).to.equal(1)
+    expect(upsertedEvents).to.have.length(1)
+    expect((upsertedEvents[0] as any)[EventDeduplicationMetadataKey]).to.deep.equal(['one'])
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Migrations for removing multiple dedup keys and bugged import path from importer is fixed so to take jsut the first index for keys.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#478 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Non-functional change (docs, style, minor refactor)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my code changes.
- [ ] I added a changeset, or this is docs-only and I added an empty changeset.
- [x] All new and existing tests passed.
