### PR TITLE
test(nip-11): add integration tests and fix max_filters mapping

### DIFF
--- a/.changeset/nip-11-integration-tests.md
+++ b/.changeset/nip-11-integration-tests.md
@@ -1,0 +1,5 @@
+---
+"nostream": patch
+---
+
+Add NIP-11 integration tests and fix max_filters mapping in relay information document.

--- a/src/handlers/request-handlers/root-request-handler.ts
+++ b/src/handlers/request-handlers/root-request-handler.ts
@@ -36,7 +36,7 @@ export const rootRequestHandler = (request: Request, response: Response, next: N
       limitation: {
         max_message_length: settings.network.maxPayloadSize,
         max_subscriptions: settings.limits?.client?.subscription?.maxSubscriptions,
-        max_filters: settings.limits?.client?.subscription?.maxFilterValues,
+        max_filters: settings.limits?.client?.subscription?.maxFilters,
         max_limit: settings.limits?.client?.subscription?.maxLimit,
         max_subid_length: settings.limits?.client?.subscription?.maxSubscriptionIdLength,
         min_prefix: settings.limits?.client?.subscription?.minPrefixLength,

--- a/test/integration/features/nip-11/nip-11.feature
+++ b/test/integration/features/nip-11/nip-11.feature
@@ -1,0 +1,25 @@
+Feature: NIP-11
+  Scenario: Relay returns information document for NIP-11 request
+    When a client requests the relay information document
+    Then the response status is 200
+    And the response Content-Type includes "application/nostr+json"
+    And the relay information document contains the required fields
+
+  Scenario: Relay information document lists supported NIPs from package.json
+    When a client requests the relay information document
+    Then the supported_nips field matches the NIPs declared in package.json
+
+  Scenario: Relay does not return information document for a non-NIP-11 Accept header
+    When a client requests the root path with Accept header "text/html"
+    Then the response Content-Type does not include "application/nostr+json"
+    And the response body is not a relay information document
+
+  Scenario: Relay information document reports max_filters from settings
+    When a client requests the relay information document
+    Then the limitation object contains a max_filters field
+
+  Scenario: WebSocket connections coexist with HTTP on the same port
+    Given someone called Alice
+    When Alice sends a text_note event with content "nostr is great"
+    And Alice subscribes to author Alice
+    Then Alice receives a text_note event from Alice with content "nostr is great"

--- a/test/integration/features/nip-11/nip-11.feature.ts
+++ b/test/integration/features/nip-11/nip-11.feature.ts
@@ -1,0 +1,72 @@
+import { Then, When, World } from '@cucumber/cucumber'
+import axios, { AxiosResponse } from 'axios'
+import chai from 'chai'
+
+import packageJson from '../../../../package.json'
+import { createSettings } from '../../../../src/factories/settings-factory'
+
+chai.use(require('sinon-chai'))
+const { expect } = chai
+
+const BASE_URL = 'http://localhost:18808'
+
+When('a client requests the relay information document', async function(this: World<Record<string, any>>) {
+  const response: AxiosResponse = await axios.get(BASE_URL, {
+    headers: { Accept: 'application/nostr+json' },
+    validateStatus: () => true,
+  })
+  this.parameters.httpResponse = response
+})
+
+When('a client requests the root path with Accept header {string}', async function(
+  this: World<Record<string, any>>,
+  acceptHeader: string,
+) {
+  const response: AxiosResponse = await axios.get(BASE_URL, {
+    headers: { Accept: acceptHeader },
+    validateStatus: () => true,
+  })
+  this.parameters.httpResponse = response
+})
+
+Then('the response status is {int}', function(this: World<Record<string, any>>, status: number) {
+  expect(this.parameters.httpResponse.status).to.equal(status)
+})
+
+Then('the response Content-Type includes {string}', function(
+  this: World<Record<string, any>>,
+  contentType: string,
+) {
+  expect(this.parameters.httpResponse.headers['content-type']).to.include(contentType)
+})
+
+Then('the response Content-Type does not include {string}', function(
+  this: World<Record<string, any>>,
+  contentType: string,
+) {
+  expect(this.parameters.httpResponse.headers['content-type']).to.not.include(contentType)
+})
+
+Then('the relay information document contains the required fields', function(this: World<Record<string, any>>) {
+  const doc = this.parameters.httpResponse.data
+  for (const field of ['name', 'description', 'pubkey', 'supported_nips', 'software', 'version']) {
+    expect(doc, `expected relay info doc to have field "${field}"`).to.have.property(field)
+  }
+})
+
+Then('the supported_nips field matches the NIPs declared in package.json', function(this: World<Record<string, any>>) {
+  const doc = this.parameters.httpResponse.data
+  expect(doc.supported_nips).to.deep.equal(packageJson.supportedNips)
+})
+
+Then('the response body is not a relay information document', function(this: World<Record<string, any>>) {
+  const body = this.parameters.httpResponse.data
+  const isRelayInfoDoc = typeof body === 'object' && body !== null && 'supported_nips' in body
+  expect(isRelayInfoDoc).to.equal(false)
+})
+
+Then('the limitation object contains a max_filters field', function(this: World<Record<string, any>>) {
+  const doc = this.parameters.httpResponse.data
+  const expectedMaxFilters = createSettings().limits?.client?.subscription?.maxFilters
+  expect(doc.limitation.max_filters).to.equal(expectedMaxFilters)
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds integration tests for the NIP-11 relay information document endpoint, plus a one-line bug fix where max_filters was being populated from maxFilterValues (2500) instead of maxFilters (10).

## Related Issue
Fixes #508 

## Motivation and Context

The root HTTP endpoint had zero integration test coverage. Any regression in NIP-11 response shape, supported NIPs list, or limitation values would go undetected.

## How Has This Been Tested?

Ran npm run docker:test:integration - all passed including the new NIP-11 scenarios

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Non-functional change (docs, style, minor refactor)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my code changes.
- [x] I added a changeset, or this is docs-only and I added an empty changeset.
- [x] All new and existing tests passed.
