### PR TITLE
Fix/update readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,8 @@
   <a href="https://github.com/cameri/nostream/blob/main/LICENSE">
     <img alt="GitHub license" src="https://img.shields.io/github/license/Cameri/nostream" />
   </a>
-  <a href='https://coveralls.io/github/Cameri/nostream?branch=main'>
-    <img  alt='Coverage Status' src='https://coveralls.io/repos/github/Cameri/nostream/badge.svg?branch=main' />
-  </a>
-  <a href='https://sonarcloud.io/project/overview?id=Cameri_nostr-ts-relay'>
-    <img alt='Sonarcloud quality gate' src='https://sonarcloud.io/api/project_badges/measure?project=Cameri_nostr&metric=alert_status' />
+  <a href='https://coveralls.io/github/cameri/nostream?branch=main'>
+    <img alt='Coverage Status' src='https://coveralls.io/repos/github/cameri/nostream/badge.svg?branch=main' />
   </a>
   <a href='https://github.com/cameri/nostream/actions'>
     <img alt='Build status' src='https://github.com/cameri/nostream/actions/workflows/checks.yml/badge.svg?branch=main&event=push' />


### PR DESCRIPTION
## Description
Remove the SonarQube badge from README.md and update the Coveralls badge to point to the correct repository and branch.

## Related Issue
Fixes #531

## Motivation and Context
The SonarQube badge is no longer maintained or relevant. The Coveralls badge URL needed to be corrected to use the canonical lowercase repository path (`cameri/nostream`) so the badge resolves properly.

## How Has This Been Tested?
This is a docs-only change. No code was modified. Badge URLs were verified manually.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Non-functional change (docs, style, minor refactor)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my code changes.
- [x] I added a changeset, or this is docs-only and I added an empty changeset.
- [x] All new and existing tests passed.