### PR TITLE
Fix/redis password url encoding

### DIFF
--- a/.changeset/polite-plants-work.md
+++ b/.changeset/polite-plants-work.md
@@ -1,0 +1,5 @@
+---
+"nostream": patch
+---
+
+fix: encode Redis password to handle special characters in fallback URL

--- a/src/cache/client.ts
+++ b/src/cache/client.ts
@@ -7,7 +7,7 @@ const logger = createLogger('cache-client')
 export const getCacheConfig = (): RedisClientOptions => ({
   url: process.env.REDIS_URI
     ? process.env.REDIS_URI
-    : `redis://${process.env.REDIS_USER}:${process.env.REDIS_PASSWORD}@${process.env.REDIS_HOST}:${process.env.REDIS_PORT}`,
+    : `redis://${process.env.REDIS_USER}:${encodeURIComponent(process.env.REDIS_PASSWORD ?? '')}@${process.env.REDIS_HOST}:${process.env.REDIS_PORT}`,
   password: process.env.REDIS_PASSWORD,
 })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Wrap `REDIS_PASSWORD` with `encodeURIComponent` when building the fallback Redis URL.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #569 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If `REDIS_PASSWORD` contains `#`, Node's URL parser treats it as a fragment and throws `TypeError: Invalid URL`. The relay fails to start with no useful error message. `encodeURIComponent` handles `#` and any other special characters safely.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified locally that `new URL()` throws with a raw `#` in the password and succeeds after percent encoding it.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Non-functional change (docs, style, minor refactor)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my code changes.
- [x] I added a changeset, or this is docs-only and I added an empty changeset.
- [x] All new and existing tests passed.
