### PR TITLE
fix: allow empty generic tag filter values

### DIFF
--- a/.changeset/generic-tags-empty-values.md
+++ b/.changeset/generic-tags-empty-values.md
@@ -1,0 +1,5 @@
+---
+"nostream": patch
+---
+
+Allow generic tag filters to match empty string tag values.

--- a/src/schemas/filter-schema.ts
+++ b/src/schemas/filter-schema.ts
@@ -14,7 +14,7 @@ export const filterSchema = z
     until: createdAtSchema.optional(),
     limit: z.number().int().min(0).optional(),
   })
-  .catchall(z.array(z.string().min(1).max(1024)))
+  .catchall(z.array(z.string().max(1024)))
   .superRefine((data, ctx) => {
     for (const key of Object.keys(data)) {
       if (!knownFilterKeys.has(key) && !isGenericTagQuery(key)) {

--- a/test/unit/repositories/event-repository.spec.ts
+++ b/test/unit/repositories/event-repository.spec.ts
@@ -383,6 +383,18 @@ describe('EventRepository', () => {
           )
         })
       })
+
+      describe('#d', () => {
+        it('selects events by empty #d tag value', () => {
+          const filters = [{ '#d': [''] }]
+
+          const query = repository.findByFilters(filters).toString()
+
+          expect(query).to.equal(
+            'select "events".* from "events" left join "event_tags" on "events"."event_id" = "event_tags"."event_id" where (event_tags.tag_name = \'d\' AND event_tags.tag_value = \'\') order by "event_created_at" asc, "event_id" asc limit 500',
+          )
+        })
+      })
     })
 
     describe('2 filters', () => {

--- a/test/unit/schemas/filter-schema.spec.ts
+++ b/test/unit/schemas/filter-schema.spec.ts
@@ -55,6 +55,17 @@ describe('NIP-01', () => {
       expect(result.value).to.deep.equal(filter)
     })
 
+    it('accepts empty strings in generic tag filters', () => {
+      const filterWithEmptyTagValue = {
+        '#d': [''],
+      }
+
+      const result = validateSchema(filterSchema)(filterWithEmptyTagValue)
+
+      expect(result.error).to.be.undefined
+      expect(result.value).to.deep.equal(filterWithEmptyTagValue)
+    })
+
     const cases = {
       ids: [{ message: 'must be an array', transform: assocPath(['ids'], null) }],
       prefixOrId: [
@@ -103,7 +114,6 @@ describe('NIP-01', () => {
           message: 'length must be less than or equal to 1024 characters long',
           transform: assocPath(['#e', 0], 'f'.repeat(1024 + 1)),
         },
-        { message: 'is not allowed to be empty', transform: assocPath(['#e', 0], '') },
       ],
       '#p': [{ message: 'must be an array', transform: assocPath(['#p'], null) }],
       '#p[0]': [
@@ -111,7 +121,6 @@ describe('NIP-01', () => {
           message: 'length must be less than or equal to 1024 characters long',
           transform: assocPath(['#p', 0], 'f'.repeat(1024 + 1)),
         },
-        { message: 'is not allowed to be empty', transform: assocPath(['#p', 0], '') },
       ],
       '#r': [{ message: 'must be an array', transform: assocPath(['#r'], null) }],
       '#r[0]': [
@@ -119,7 +128,6 @@ describe('NIP-01', () => {
           message: 'length must be less than or equal to 1024 characters long',
           transform: assocPath(['#r', 0], 'f'.repeat(1024 + 1)),
         },
-        { message: 'is not allowed to be empty', transform: assocPath(['#r', 0], '') },
       ],
     }
 

--- a/test/unit/utils/event.spec.ts
+++ b/test/unit/utils/event.spec.ts
@@ -258,6 +258,25 @@ describe('NIP-01', () => {
 
 describe('NIP-12', () => {
   let event: Event
+
+  describe('#d filter', () => {
+    beforeEach(() => {
+      event = {
+        id: 'cf8de9db67a1d7203512d1d81e6190f5e53abfdc0ac90275f67172b65a5b09a0',
+        pubkey: 'e8b487c079b0f67c695ae6c4c2552a47f38adfa2533cc5926bd2c102942fdcb7',
+        created_at: 1645030752,
+        kind: EventKinds.PARAMETERIZED_REPLACEABLE_FIRST,
+        tags: [['d', '']],
+        content: 'empty d tag',
+        sig: '53d12018d036092794366283eca36df4e0cabd014b6e91bbf684c8bb9bbbe9dedafa77b6b928587e11e05e036227598dded8713e8da17d55076e12242b361542',
+      }
+    })
+
+    it('returns true if #d filter contains an empty tag value in the event', () => {
+      expect(isEventMatchingFilter({ '#d': [''] })(event)).to.be.true
+    })
+  })
+
   describe('#r filter', () => {
     beforeEach(() => {
       event = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Generic tag filters should be able to match empty tag values like {"#d":[""]}. The matcher/query path already treats empty tag values as normal values, but validation rejected them before matching.

This relaxes generic tag filter validation while keeping ids/authors validation unchanged, and adds schema/runtime coverage.

## Related Issue
Fixes #259 

## Motivation and Context
The schema rejects `{"#d":[""]}` with `invalid: "[2].#d[0]" is not allowed to be empty`, but the matcher and query path already accept empty tag values. Real events with `["d", ""]` exist on the network (NIP-23, NIP-58 badges) and other relays accept this filter. This aligns validation with existing behavior.

## How Has This Been Tested?
- `pnpm exec mocha test/unit/schemas/filter-schema.spec.ts test/unit/utils/event.spec.ts test/unit/repositories/event-repository.spec.ts`
- `pnpm build:check`
- `pnpm exec biome lint src/schemas/filter-schema.ts test/unit/schemas/filter-schema.spec.ts test/unit/utils/event.spec.ts test/unit/repositories/event-repository.spec.ts`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Non-functional change (docs, style, minor refactor)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my code changes.
- [x] I added a changeset, or this is docs-only and I added an empty changeset.
- [x] All new and existing tests passed.
