### PR TITLE
fix: check payments.enabled in callback route middleware

### DIFF
--- a/.changeset/callback-check-payments-enabled.md
+++ b/.changeset/callback-check-payments-enabled.md
@@ -1,0 +1,5 @@
+---
+"nostream": patch
+---
+
+fix: check payments.enabled in callback route middleware

--- a/src/routes/callbacks/index.ts
+++ b/src/routes/callbacks/index.ts
@@ -12,7 +12,7 @@ const router: Router = Router()
 const requireProcessor = (name: string) =>
   (_req: Request, res: Response, next: NextFunction) => {
     const settings = createSettings()
-    if (settings.payments?.processor !== name) {
+    if (!settings.payments?.enabled || settings.payments.processor !== name) {
       res.status(403).send('Forbidden')
       return
     }

--- a/test/integration/features/callbacks/opennode-callback.feature.ts
+++ b/test/integration/features/callbacks/opennode-callback.feature.ts
@@ -36,7 +36,16 @@ Given('OpenNode callback processing is enabled', function () {
     ...settings,
     payments: {
       ...(settings?.payments ?? {}),
+      enabled: true,
       processor: 'opennode',
+    },
+    paymentsProcessors: {
+      ...(settings?.paymentsProcessors ?? {}),
+      opennode: {
+        ...(settings?.paymentsProcessors?.opennode ?? {}),
+        baseURL: 'api.opennode.com',
+        callbackBaseURL: 'http://localhost:18808/callbacks/opennode',
+      },
     },
   }
 

--- a/test/unit/routes/callbacks.spec.ts
+++ b/test/unit/routes/callbacks.spec.ts
@@ -16,7 +16,7 @@ describe('callbacks router', () => {
     receivedBody = undefined
 
     createSettingsStub = Sinon.stub(settingsFactory, 'createSettings').returns({
-      payments: { processor: 'opennode' },
+      payments: { enabled: true, processor: 'opennode' },
     } as any)
 
     createOpenNodeCallbackControllerStub = Sinon.stub(openNodeControllerFactory, 'createOpenNodeCallbackController').returns({


### PR DESCRIPTION
## Description

The `requireProcessor` middleware now also checks `settings.payments.enabled` before allowing callback requests through. Previously it only verified the processor name matched, which meant a relay with payments disabled but a processor configured could still accept callbacks.

## Related Issue

Follow-up to #597

## Motivation and Context

A relay operator might have `payments.enabled: false` with a processor still configured (e.g. during setup or after disabling payments). Without this check, callback endpoints would still accept and process requests so the middleware should reject early in that case.

## How Has This Been Tested?

- All 1261 unit tests passing
- Updated route unit test stub to set `enabled: true`
- Updated OpenNode integration test setup to set `enabled: true`

## Types of changes

- [x] Bug fix
