### PR TITLE
feat: add NIP-42 client authentication

### DIFF
--- a/.changeset/vast-friends-march.md
+++ b/.changeset/vast-friends-march.md
@@ -1,0 +1,5 @@
+---
+"nostream": minor
+---
+
+feat: add NIP-42 types, schemas and constants

--- a/src/@types/messages.ts
+++ b/src/@types/messages.ts
@@ -12,13 +12,14 @@ export enum MessageType {
   OK = 'OK',
   COUNT = 'COUNT',
   CLOSED = 'CLOSED',
+  AUTH = 'AUTH',
 }
 
-export type IncomingMessage = (SubscribeMessage | IncomingEventMessage | UnsubscribeMessage | CountMessage) & {
+export type IncomingMessage = (SubscribeMessage | IncomingEventMessage | UnsubscribeMessage | CountMessage | AuthMessage) & {
   [ContextMetadataKey]?: ContextMetadata
 }
 
-export type OutgoingMessage = OutgoingEventMessage | EndOfStoredEventsNotice | NoticeMessage | CommandResult | CountResultMessage | ClosedMessage
+export type OutgoingMessage = OutgoingEventMessage | EndOfStoredEventsNotice | NoticeMessage | CommandResult | CountResultMessage | ClosedMessage | AuthChallengeMessage
 
 export type SubscribeMessage = {
   [index in Range<2, 100>]: SubscriptionFilter
@@ -88,4 +89,15 @@ export interface ClosedMessage {
   0: MessageType.CLOSED
   1: SubscriptionId
   2: string
+}
+
+// NIP-42
+export interface AuthMessage {
+  0: MessageType.AUTH
+  1: Event
+}
+
+export interface AuthChallengeMessage {
+  0: MessageType.AUTH
+  1: string
 }

--- a/src/constants/base.ts
+++ b/src/constants/base.ts
@@ -45,6 +45,8 @@ export enum EventKinds {
   REPLACEABLE_LAST = 19999,
   // Ephemeral events
   EPHEMERAL_FIRST = 20000,
+  // NIP-42: Client Authentication
+  AUTH = 22242,
   EPHEMERAL_LAST = 29999,
   // Parameterized replaceable events
   PARAMETERIZED_REPLACEABLE_FIRST = 30000,
@@ -72,6 +74,9 @@ export enum EventTags {
   Emoji = 'emoji',
   // NIP-12: geohash tag for location-based queries
   Geohash = 'g',
+  // NIP-42: Authentication tags
+  Challenge = 'challenge',
+  AuthRelay = 'relay',
   // Marmot Protocol MIP-03: group ID for filtering kind:445 Group Events
   Group = 'h',
 }

--- a/src/schemas/message-schema.ts
+++ b/src/schemas/message-schema.ts
@@ -55,4 +55,7 @@ export const countMessageSchema = z
 
 export const closeMessageSchema = z.tuple([z.literal(MessageType.CLOSE), subscriptionSchema])
 
-export const messageSchema = z.union([eventMessageSchema, reqMessageSchema, closeMessageSchema, countMessageSchema])
+// NIP-42
+export const authMessageSchema = z.tuple([z.literal(MessageType.AUTH), eventSchema])
+
+export const messageSchema = z.union([eventMessageSchema, reqMessageSchema, closeMessageSchema, countMessageSchema, authMessageSchema])

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1,4 +1,5 @@
 import {
+  AuthChallengeMessage,
   ClosedMessage,
   CountResultMessage,
   CountResultPayload,
@@ -39,6 +40,11 @@ export const createCountResultMessage = (queryId: SubscriptionId, payload: Count
 
 export const createClosedMessage = (queryId: SubscriptionId, reason: string): ClosedMessage => {
   return [MessageType.CLOSED, queryId, reason]
+}
+
+// NIP-42
+export const createAuthChallengeMessage = (challenge: string): AuthChallengeMessage => {
+  return [MessageType.AUTH, challenge]
 }
 
 export const createSubscriptionMessage = (

--- a/test/unit/schemas/message-schema.spec.ts
+++ b/test/unit/schemas/message-schema.spec.ts
@@ -167,5 +167,42 @@ describe('NIP-01', () => {
         expect(result).to.have.property('error').that.is.not.undefined
       })
     })
+
+    describe('AUTH', () => {
+      let events: Event[]
+      beforeEach(() => {
+        events = getEvents()
+      })
+
+      it('returns same message if valid', () => {
+        const event = events[0]
+        message = ['AUTH', event] as any
+
+        const result = validateSchema(messageSchema)(message)
+        expect(result.error).to.be.undefined
+        expect(result).to.have.deep.property('value', message)
+      })
+
+      it('returns error if event is missing', () => {
+        message = ['AUTH'] as any
+
+        const result = validateSchema(messageSchema)(message)
+        expect(result).to.have.property('error').that.is.not.undefined
+      })
+
+      it('returns error if event is not an object', () => {
+        message = ['AUTH', 'not-an-event'] as any
+
+        const result = validateSchema(messageSchema)(message)
+        expect(result).to.have.property('error').that.is.not.undefined
+      })
+
+      it('returns error if event is null', () => {
+        message = ['AUTH', null] as any
+
+        const result = validateSchema(messageSchema)(message)
+        expect(result).to.have.property('error').that.is.not.undefined
+      })
+    })
   })
 })


### PR DESCRIPTION
## Description

First of two PRs for NIP-42. This one just adds the types, constants and schema.

- added `EventKinds.AUTH` (22242), `EventTags.Challenge` and `EventTags.AuthRelay` to `constants/base.ts`
- added `MessageType.AUTH`, `AuthMessage` and `AuthChallengeMessage` to `@types/messages.ts`
- added `authMessageSchema` to `message-schema.ts` and wired it into the main `messageSchema` union
- added `createAuthChallengeMessage` helper to `utils/messages.ts`

The handler, WebSocket wiring and session state are in the follow-up PR.

## Related Issue

Closes #619

## Motivation and Context

Needed a clean base before touching the adapter. Keeping the type changes separate makes the actual handler PR much easier to review.

## How Has This Been Tested?

Added schema unit tests for the new `authMessageSchema`. All 1265 tests pass, lint and tsc clean.

## Types of changes
- [ ] Non-functional change (docs, style, minor refactor)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my code changes.
- [x] I added a changeset, or this is docs-only and I added an empty changeset.
- [x] All new and existing tests passed.
