### PR TITLE
feat: wot#1 config

### DIFF
--- a/.changeset/lemon-views-know.md
+++ b/.changeset/lemon-views-know.md
@@ -1,0 +1,5 @@
+---
+"nostream": minor
+---
+
+new user-facing config field

--- a/resources/default-settings.yaml
+++ b/resources/default-settings.yaml
@@ -62,6 +62,17 @@ nip05:
   domainBlacklist: []
 nip45:
   enabled: true
+wot:
+  # Web of Trust filtering. When enabled, only events from pubkeys within
+  # the relay owner's 2-hop follow graph are accepted.
+  enabled: false
+  # The relay owner's pubkey in hex. This is the root of the trust graph.
+  # Required when enabled is true.
+  seedPubkey: ""
+  # A pubkey must be followed by at least this many 1-hop accounts to be trusted.
+  minimumFollowers: 1
+  # Hours between full trust graph rebuilds.
+  refreshIntervalHours: 24
 network:
   maxPayloadSize: 524288
   # Uncomment only when using a trusted reverse proxy and configuring trustedProxies.

--- a/src/@types/settings.ts
+++ b/src/@types/settings.ts
@@ -266,6 +266,25 @@ export interface Nip05Settings {
   domainBlacklist?: string[]
 }
 
+export interface WoTSettings {
+  enabled: boolean
+  /**
+   * The relay owner's pubkey (hex). The trust graph is rooted here.
+   * Required when enabled is true.
+   */
+  seedPubkey: Pubkey
+  /**
+   * Minimum number of 1-hop follows a pubkey must have to enter the trust filter.
+   * Defaults to 1.
+   */
+  minimumFollowers: number
+  /**
+   * How many hours between full trust graph rebuilds.
+   * Defaults to 24.
+   */
+  refreshIntervalHours: number
+}
+
 export interface Settings {
   info: Info
   payments?: Payments
@@ -276,4 +295,5 @@ export interface Settings {
   mirroring?: Mirroring
   nip05?: Nip05Settings
   nip45?: Nip45Settings
+  wot?: WoTSettings
 }

--- a/test/unit/utils/settings.spec.ts
+++ b/test/unit/utils/settings.spec.ts
@@ -2,6 +2,8 @@ import { expect } from 'chai'
 import fs from 'fs'
 import { join } from 'path'
 import Sinon from 'sinon'
+import { mergeDeepRight } from 'ramda'
+import { Settings } from '../../../src/@types/settings'
 
 import { SettingsFileTypes, SettingsStatic } from '../../../src/utils/settings'
 
@@ -256,6 +258,41 @@ describe('SettingsStatic', () => {
         Sinon.match.string,
         { encoding: 'utf-8' },
       )
+    })
+  })
+
+  describe('WoT settings defaults', () => {
+    it('default-settings.yaml contains a wot block with enabled: false', () => {
+      const defaults = SettingsStatic.loadAndParseYamlFile(
+        SettingsStatic.getDefaultSettingsFilePath()
+      )
+      expect(defaults).to.have.nested.property('wot.enabled', false)
+      expect(defaults).to.have.nested.property('wot.seedPubkey', '')
+      expect(defaults).to.have.nested.property('wot.minimumFollowers', 1)
+      expect(defaults).to.have.nested.property('wot.refreshIntervalHours', 24)
+    })
+
+    it('merging an empty user config preserves wot defaults', () => {
+      const defaults = SettingsStatic.loadAndParseYamlFile(
+        SettingsStatic.getDefaultSettingsFilePath()
+      )
+      const merged = mergeDeepRight(defaults, {}) as Settings
+      expect(merged.wot?.enabled).to.equal(false)
+      expect(merged.wot?.minimumFollowers).to.equal(1)
+      expect(merged.wot?.refreshIntervalHours).to.equal(24)
+    })
+
+    it('user config wot block overrides defaults', () => {
+      const defaults = SettingsStatic.loadAndParseYamlFile(
+        SettingsStatic.getDefaultSettingsFilePath()
+      )
+      const userConfig = { wot: { enabled: true, seedPubkey: 'abc123', minimumFollowers: 3 } }
+      const merged = mergeDeepRight(defaults, userConfig) as Settings
+      expect(merged.wot?.enabled).to.equal(true)
+      expect(merged.wot?.seedPubkey).to.equal('abc123')
+      expect(merged.wot?.minimumFollowers).to.equal(3)
+      // non-overridden fields stay as defaults
+      expect(merged.wot?.refreshIntervalHours).to.equal(24)
     })
   })
 })

--- a/test/unit/utils/settings.spec.ts
+++ b/test/unit/utils/settings.spec.ts
@@ -272,16 +272,6 @@ describe('SettingsStatic', () => {
       expect(defaults).to.have.nested.property('wot.refreshIntervalHours', 24)
     })
 
-    it('merging an empty user config preserves wot defaults', () => {
-      const defaults = SettingsStatic.loadAndParseYamlFile(
-        SettingsStatic.getDefaultSettingsFilePath()
-      )
-      const merged = mergeDeepRight(defaults, {}) as Settings
-      expect(merged.wot?.enabled).to.equal(false)
-      expect(merged.wot?.minimumFollowers).to.equal(1)
-      expect(merged.wot?.refreshIntervalHours).to.equal(24)
-    })
-
     it('user config wot block overrides defaults', () => {
       const defaults = SettingsStatic.loadAndParseYamlFile(
         SettingsStatic.getDefaultSettingsFilePath()


### PR DESCRIPTION
## Description
Closes (#621)

Adds the WotSettings interface and a wot: config block with safe defaults (enabled: false). This is purely additive — no runtime behaviour changes. Subsequent PRs for the graph service, worker process, and admission guard all depend on these types existing.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my code changes.
- [x] I added a changeset, or this is docs-only and I added an empty changeset.
- [x] All new and existing tests passed.
