### PR TITLE
refactor: simplify EventRepository query/purge complexity

### DIFF
--- a/.changeset/quick-cats-agree.md
+++ b/.changeset/quick-cats-agree.md
@@ -1,0 +1,5 @@
+---
+"nostream": patch
+---
+
+Refactor EventRepository query construction to reduce method complexity.

--- a/src/repositories/event-repository.ts
+++ b/src/repositories/event-repository.ts
@@ -1,31 +1,16 @@
 import {
-  __,
   always,
   applySpec,
-  complement,
-  cond,
-  equals,
-  evolve,
-  filter,
-  forEach,
-  forEachObjIndexed,
-  groupBy,
   ifElse,
-  invoker,
   is,
-  isEmpty,
   isNil,
   map,
-  modulo,
-  nth,
   omit,
   path,
   paths,
   pipe,
   prop,
   propSatisfies,
-  T,
-  toPairs,
 } from 'ramda'
 
 import {
@@ -43,20 +28,15 @@ import { createLogger } from '../factories/logger-factory'
 import { isGenericTagQuery, isGeohashPrefixCriterion, stripGeohashPrefixWildcard } from '../utils/filter'
 import { SubscriptionFilter } from '../@types/subscription'
 
-const even = pipe(modulo(__, 2), equals(0))
-
-const groupByLengthSpec = groupBy<string, 'exact' | 'even' | 'odd'>(
-  pipe(
-    prop('length'),
-    cond([
-      [equals(64), always('exact')],
-      [even, always('even')],
-      [T, always('odd')],
-    ]),
-  ),
-)
-
 const logger = createLogger('event-repository')
+const RETENTION_BATCH_SIZE = 1000
+const SECONDS_PER_DAY = 86400
+
+type HexCriterionGroups = {
+  exact: string[]
+  even: string[]
+  odd: string[]
+}
 
 export class EventRepository implements IEventRepository {
   public constructor(
@@ -135,37 +115,7 @@ export class EventRepository implements IEventRepository {
   }
 
   private applyFilterConditions(builder: any, currentFilter: SubscriptionFilter): boolean {
-    forEachObjIndexed((tableFields: string[], filterName: string | number) => {
-      builder.andWhere((bd) => {
-        cond([
-          [isEmpty, () => void bd.whereRaw('1 = 0')],
-          [
-            complement(isNil),
-            pipe(
-              groupByLengthSpec,
-              evolve({
-                exact: (pubkeys: string[]) =>
-                  tableFields.forEach((tableField) => bd.orWhereIn(tableField, pubkeys.map(toBuffer))),
-                even: forEach((prefix: string) =>
-                  tableFields.forEach((tableField) =>
-                    bd.orWhereRaw(`substring("${tableField}" from 1 for ?) = ?`, [prefix.length >> 1, toBuffer(prefix)]),
-                  ),
-                ),
-                odd: forEach((prefix: string) =>
-                  tableFields.forEach((tableField) =>
-                    bd.orWhereRaw(`substring("${tableField}" from 1 for ?) BETWEEN ? AND ?`, [
-                      (prefix.length >> 1) + 1,
-                      `\\x${prefix}0`,
-                      `\\x${prefix}f`,
-                    ]),
-                  ),
-                ),
-              } as any),
-            ),
-          ],
-        ])(currentFilter[filterName] as string[])
-      })
-    })({ authors: ['event_pubkey'], ids: ['event_id'] })
+    this.applyHexFilterConditions(builder, currentFilter)
 
     if (Array.isArray(currentFilter.kinds)) {
       builder.whereIn('event_kind', currentFilter.kinds)
@@ -179,46 +129,106 @@ export class EventRepository implements IEventRepository {
       builder.where('event_created_at', '<=', currentFilter.until)
     }
 
-    const andWhereRaw = invoker(1, 'andWhereRaw')
-    const orWhereRaw = invoker(2, 'orWhereRaw')
-
-    let isTagQuery = false
-    pipe(
-      toPairs,
-      filter(pipe(nth(0) as () => string, isGenericTagQuery)) as any,
-      forEach(([filterName, criteria]: [string, string[]]) => {
-        isTagQuery = true
-        builder.andWhere((bd) => {
-          ifElse(
-            isEmpty,
-            () => andWhereRaw('1 = 0', bd),
-            forEach(
-              (criterion: string) => {
-                if (isGeohashPrefixCriterion(filterName, criterion)) {
-                  return void orWhereRaw(
-                    'event_tags.tag_name = ? AND event_tags.tag_value LIKE ?',
-                    [filterName[1], `${stripGeohashPrefixWildcard(criterion)}%`],
-                    bd,
-                  )
-                }
-
-                return void orWhereRaw(
-                  'event_tags.tag_name = ? AND event_tags.tag_value = ?',
-                  [filterName[1], criterion],
-                  bd,
-                )
-              },
-            ),
-          )(criteria)
-        })
-      }),
-    )(currentFilter as any)
+    const isTagQuery = this.applyGenericTagFilterConditions(builder, currentFilter)
 
     if (isTagQuery) {
       builder.leftJoin('event_tags', 'events.event_id', 'event_tags.event_id')
     }
 
     return isTagQuery
+  }
+
+  private applyHexFilterConditions(builder: any, currentFilter: SubscriptionFilter): void {
+    builder.andWhere((bd) => {
+      this.applyHexCriteria(bd, ['event_pubkey'], currentFilter.authors)
+    })
+
+    builder.andWhere((bd) => {
+      this.applyHexCriteria(bd, ['event_id'], currentFilter.ids)
+    })
+  }
+
+  private applyHexCriteria(builder: any, tableFields: string[], criteria?: string[]): void {
+    if (typeof criteria === 'undefined') {
+      return
+    }
+
+    if (!criteria.length) {
+      builder.whereRaw('1 = 0')
+      return
+    }
+
+    const groups = this.groupHexCriteria(criteria)
+
+    tableFields.forEach((tableField) => {
+      if (groups.exact.length) {
+        builder.orWhereIn(tableField, groups.exact.map(toBuffer))
+      }
+
+      groups.even.forEach((prefix) => {
+        builder.orWhereRaw(`substring("${tableField}" from 1 for ?) = ?`, [prefix.length >> 1, toBuffer(prefix)])
+      })
+
+      groups.odd.forEach((prefix) => {
+        builder.orWhereRaw(`substring("${tableField}" from 1 for ?) BETWEEN ? AND ?`, [
+          (prefix.length >> 1) + 1,
+          `\\x${prefix}0`,
+          `\\x${prefix}f`,
+        ])
+      })
+    })
+  }
+
+  private groupHexCriteria(criteria: string[]): HexCriterionGroups {
+    return criteria.reduce<HexCriterionGroups>(
+      (groups, criterion) => {
+        if (criterion.length === 64) {
+          groups.exact.push(criterion)
+        } else if (criterion.length % 2 === 0) {
+          groups.even.push(criterion)
+        } else {
+          groups.odd.push(criterion)
+        }
+
+        return groups
+      },
+      {
+        exact: [],
+        even: [],
+        odd: [],
+      },
+    )
+  }
+
+  private applyGenericTagFilterConditions(builder: any, currentFilter: SubscriptionFilter): boolean {
+    const tagFilters = Object.entries(currentFilter).filter(([filterName]) => isGenericTagQuery(filterName))
+
+    tagFilters.forEach(([filterName, criteria]) => {
+      this.applyGenericTagCriteria(builder, filterName, criteria as string[])
+    })
+
+    return tagFilters.length > 0
+  }
+
+  private applyGenericTagCriteria(builder: any, filterName: string, criteria: string[]): void {
+    builder.andWhere((bd) => {
+      if (!criteria.length) {
+        bd.andWhereRaw('1 = 0')
+        return
+      }
+
+      criteria.forEach((criterion) => {
+        if (isGeohashPrefixCriterion(filterName, criterion)) {
+          bd.orWhereRaw('event_tags.tag_name = ? AND event_tags.tag_value LIKE ?', [
+            filterName[1],
+            `${stripGeohashPrefixWildcard(criterion)}%`,
+          ])
+          return
+        }
+
+        bd.orWhereRaw('event_tags.tag_name = ? AND event_tags.tag_value = ?', [filterName[1], criterion])
+      })
+    })
   }
 
   public async create(event: Event): Promise<number> {
@@ -403,83 +413,22 @@ export class EventRepository implements IEventRepository {
       })
     }
 
-    const retentionLimit = now - maxDays * 86400
-    const batchSize = 1000
+    const retentionLimit = now - maxDays * SECONDS_PER_DAY
 
     logger(
       'deleting expired and retained events (retentionLimit: %d, now: %d, batchSize: %d)',
       retentionLimit,
       now,
-      batchSize,
+      RETENTION_BATCH_SIZE,
     )
 
-    const kindWhitelist = [
-      ...(Array.isArray(options?.kindWhitelist) ? options.kindWhitelist : []),
-      EventKinds.REQUEST_TO_VANISH,
-    ].reduce<(number | [number, number])[]>((result, item) => {
-      const key = Array.isArray(item) ? `range:${item[0]}-${item[1]}` : `kind:${item}`
-
-      if (
-        !result.some((existing) => {
-          const existingKey = Array.isArray(existing) ? `range:${existing[0]}-${existing[1]}` : `kind:${existing}`
-          return existingKey === key
-        })
-      ) {
-        result.push(item)
-      }
-
-      return result
-    }, [])
-
-    const candidates = this.masterDbClient('events')
-      .select('event_id')
-      .where(function () {
-        this.where('expires_at', '<', now).orWhereNotNull('deleted_at').orWhere('event_created_at', '<', retentionLimit)
-      })
-      .modify((query) => {
-        query.whereNot((builder) => {
-          kindWhitelist.forEach((kindOrRange) => {
-            if (Array.isArray(kindOrRange)) {
-              builder.orWhereBetween('event_kind', kindOrRange)
-            } else {
-              builder.orWhere('event_kind', kindOrRange)
-            }
-          })
-        })
-
-        if (Array.isArray(options?.pubkeyWhitelist) && options.pubkeyWhitelist.length > 0) {
-          query.whereNotIn('event_pubkey', map(toBuffer)(options.pubkeyWhitelist))
-        }
-      })
-      .limit(batchSize)
+    const candidates = this.buildRetentionCandidateQuery(now, retentionLimit, options)
 
     const query = this.masterDbClient('events')
       .whereIn('event_id', candidates)
       .del(['deleted_at', 'expires_at', 'event_created_at'])
 
-    const mapToCounts = (
-      deletedRows: Pick<DBEvent, 'deleted_at' | 'expires_at' | 'event_created_at'>[],
-    ): EventPurgeCounts =>
-      deletedRows.reduce(
-        (counts, row) => {
-          if (row.deleted_at) {
-            counts.deleted += 1
-          } else if (typeof row.expires_at === 'number' && row.expires_at < now) {
-            counts.expired += 1
-          } else if (row.event_created_at < retentionLimit) {
-            counts.retained += 1
-          }
-
-          return counts
-        },
-        {
-          deleted: 0,
-          expired: 0,
-          retained: 0,
-        },
-      )
-
-    const getPromise = () => query.then((rows: any) => mapToCounts(rows))
+    const getPromise = () => query.then((rows: any) => this.mapToPurgeCounts(rows, now, retentionLimit))
 
     return {
       then: <T1, T2>(
@@ -490,5 +439,71 @@ export class EventRepository implements IEventRepository {
       finally: (onfinally?: (() => void) | null) => getPromise().finally(onfinally as any),
       toString: (): string => query.toString(),
     } as Promise<EventPurgeCounts> & { toString(): string }
+  }
+
+  private buildRetentionCandidateQuery(
+    now: number,
+    retentionLimit: number,
+    options?: EventRetentionOptions,
+  ): any {
+    return this.masterDbClient('events')
+      .select('event_id')
+      .where(function () {
+        this.where('expires_at', '<', now).orWhereNotNull('deleted_at').orWhere('event_created_at', '<', retentionLimit)
+      })
+      .modify((query) => {
+        this.applyRetentionKindWhitelist(query, options?.kindWhitelist)
+
+        if (Array.isArray(options?.pubkeyWhitelist) && options.pubkeyWhitelist.length > 0) {
+          query.whereNotIn('event_pubkey', map(toBuffer)(options.pubkeyWhitelist))
+        }
+      })
+      .limit(RETENTION_BATCH_SIZE)
+  }
+
+  private applyRetentionKindWhitelist(query: any, kindWhitelist?: EventRetentionOptions['kindWhitelist']): void {
+    const seen = new Set<string>()
+    const configuredWhitelist = Array.isArray(kindWhitelist) ? kindWhitelist : []
+    const dedupedWhitelist = [...configuredWhitelist, EventKinds.REQUEST_TO_VANISH].filter((item) => {
+      const key = Array.isArray(item) ? `range:${item[0]}-${item[1]}` : `kind:${item}`
+
+      if (seen.has(key)) {
+        return false
+      }
+
+      seen.add(key)
+      return true
+    })
+    query.whereNot((builder) => {
+      dedupedWhitelist.forEach((kindOrRange) => {
+        if (Array.isArray(kindOrRange)) {
+          builder.orWhereBetween('event_kind', kindOrRange)
+        } else {
+          builder.orWhere('event_kind', kindOrRange)
+        }
+      })
+    })
+  }
+
+  private mapToPurgeCounts(
+    deletedRows: Pick<DBEvent, 'deleted_at' | 'expires_at' | 'event_created_at'>[],
+    now: number,
+    retentionLimit: number,
+  ): EventPurgeCounts {
+    return deletedRows.reduce((counts, row) => {
+      if (row.deleted_at) {
+        counts.deleted += 1
+      } else if (typeof row.expires_at === 'number' && row.expires_at < now) {
+        counts.expired += 1
+      } else if (row.event_created_at < retentionLimit) {
+        counts.retained += 1
+      }
+
+      return counts
+    }, {
+      deleted: 0,
+      expired: 0,
+      retained: 0,
+    })
   }
 }

--- a/test/unit/repositories/event-repository.spec.ts
+++ b/test/unit/repositories/event-repository.spec.ts
@@ -638,6 +638,53 @@ describe('EventRepository', () => {
     })
   })
 
+  describe('deleteExpiredAndRetained', () => {
+    it('returns zero counts when retention is disabled', async () => {
+      const result = await repository.deleteExpiredAndRetained({ maxDays: 0 })
+
+      expect(result).to.deep.equal({
+        deleted: 0,
+        expired: 0,
+        retained: 0,
+      })
+    })
+
+    it('builds a purge query with deduplicated kind and pubkey whitelists', () => {
+      sandbox.useFakeTimers(new Date('2023-11-14T22:13:20.000Z'))
+
+      const query = repository
+        .deleteExpiredAndRetained({
+          maxDays: 7,
+          kindWhitelist: [1, [10000, 19999], 1],
+          pubkeyWhitelist: ['001122'],
+        })
+        .toString()
+
+      expect(query).to.equal(
+        'delete from "events" where "event_id" in (select "event_id" from "events" where ("expires_at" < 1700000000 or "deleted_at" is not null or "event_created_at" < 1699395200) and not ("event_kind" = 1 or "event_kind" between 10000 and 19999 or "event_kind" = 62) and "event_pubkey" not in (X\'001122\') limit 1000) returning "deleted_at", "expires_at", "event_created_at"',
+      )
+    })
+
+    it('maps purged rows to deleted, expired, and retained counts', () => {
+      const result = (repository as any).mapToPurgeCounts(
+        [
+          { deleted_at: new Date(), expires_at: null, event_created_at: 90 },
+          { deleted_at: null, expires_at: 95, event_created_at: 90 },
+          { deleted_at: null, expires_at: null, event_created_at: 40 },
+          { deleted_at: null, expires_at: null, event_created_at: 80 },
+        ],
+        100,
+        50,
+      )
+
+      expect(result).to.deep.equal({
+        deleted: 1,
+        expired: 1,
+        retained: 1,
+      })
+    })
+  })
+
   describe('upsert', () => {
     it('replaces event based on event_pubkey and event_kind', () => {
       const event: Event = {


### PR DESCRIPTION
## Description
This PR simplifies EventRepository by breaking down high-complexity logic in filter construction and retention purge flow.
It refactors applyFilterConditions into smaller helpers for hex and generic tag criteria handling, while preserving SQL behavior.
It also refactors deleteExpiredAndRetained into clearer steps (candidate selection, whitelist handling, purge count mapping).

## Related Issue
Fixes- #46 

## Types of changes

- [x] Non-functional change (docs, style, minor refactor)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my code changes.
- [x] I added a changeset, or this is docs-only and I added an empty changeset.
- [x] All new and existing tests passed.
