### PR TITLE
refactor(http): remove deprecated remote_ip_header fallback

### DIFF
--- a/.changeset/remove-deprecated-remote-ip-header.md
+++ b/.changeset/remove-deprecated-remote-ip-header.md
@@ -1,0 +1,5 @@
+---
+"nostream": minor
+---
+
+refactor(http): remove deprecated network.remote_ip_header fallback and rely on network.remoteIpHeader

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -27,16 +27,21 @@ const isTrustedProxy = (ipAddress: string, settings: Settings): boolean => {
   })
 }
 
-export const getRemoteAddress = (request: IncomingMessage, settings: Settings): string => {
-  let header: string | undefined
-  // TODO: Remove deprecation warning
-  if ('network' in settings && 'remote_ip_header' in settings.network) {
-    logger.warn(`WARNING: Setting network.remote_ip_header is deprecated and will be removed in a future version.
-        Use network.remoteIpHeader instead.`)
-    header = settings.network['remote_ip_header'] as string
-  } else {
-    header = settings.network.remoteIpHeader as string
+const warnIfDeprecatedRemoteIpHeaderIsConfigured = (settings: Settings): void => {
+  const networkSettings = settings.network as Record<string, unknown> | undefined
+  const deprecatedHeader = networkSettings?.remote_ip_header
+
+  if (typeof deprecatedHeader === 'string' && deprecatedHeader.trim() !== '') {
+    logger.warn(
+      'WARNING: network.remote_ip_header is deprecated and no longer used. Rename it to network.remoteIpHeader to restore forwarded header handling.',
+    )
   }
+}
+
+export const getRemoteAddress = (request: IncomingMessage, settings: Settings): string => {
+  warnIfDeprecatedRemoteIpHeaderIsConfigured(settings)
+
+  const header = settings.network?.remoteIpHeader as string
 
   const trustedProxies = settings.network?.trustedProxies
   if (header && (!Array.isArray(trustedProxies) || trustedProxies.length === 0)) {

--- a/test/unit/utils/http.spec.ts
+++ b/test/unit/utils/http.spec.ts
@@ -21,16 +21,7 @@ describe('getRemoteAddress', () => {
     } as any
   })
 
-  it('returns address using network.remote_ip_address when set', () => {
-    expect(
-      getRemoteAddress(
-        request,
-        { network: { 'remote_ip_header': header, trustedProxies: [socketAddress] } } as any,
-      )
-    ).to.equal(address)
-  })
-
-  it('returns address using network.remoteIpAddress when set', () => {
+  it('returns address using network.remoteIpHeader when set', () => {
     expect(
       getRemoteAddress(
         request,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR removes deprecated network.remote_ip_header support.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Non-functional change (docs, style, minor refactor)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my code changes.
- [x] I added a changeset, or this is docs-only and I added an empty changeset.
- [x] All new and existing tests passed.
