### PR TITLE
ci: add publish script to changesets workflow

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -34,10 +34,11 @@ jobs:
       - run: git config user.name "github-actions[bot]"
       - run: git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Create Release Pull Request
+      - name: Create Release Pull Request or Publish
         uses: changesets/action@v1
         with:
           version: pnpm run changeset:version
+          publish: pnpm run changeset:publish
           createGithubReleases: true
           title: "chore: release new version 🚀"
           commit: "chore: version packages"


### PR DESCRIPTION
## Problem

The `changesets/action` was missing a `publish` script, so when a release PR was merged, it logged:

> Not publishing because no publish script found.

No tag or GitHub release was ever created automatically.

## Fix

Add `publish: pnpm run changeset:publish` to the action. The `changeset:publish` script already exists in `package.json` and `.changeset/config.json` has `privatePackages: { tag: true }`, so this will create git tags and GitHub releases without publishing to npm.