### PR TITLE
docs: add v3.0.0 contributors to README [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,13 +641,34 @@ I'm Cameri on most social networks. You can find me on Nostr by npub1qqqqqqyz0la
 
 # Contributors (A-Z)
 
-- Anton Livaja
-- Juan Angel
-- Kevin Smith
-- Saransh Sharma
-- swissrouting
+- Abhinav Rathee
 - André Neves
+- Anshuman
+- Anton Livaja
+- archief2910
+- Chetan Reddy Kodidela
+- Divyanshu Kumar
+- Ferryx
+- Juan Angel
+- Kanishka
+- Kartik
+- Kevin Smith
+- Khadar Vali
+- Khushal
+- Kushagra Kinra
+- Mahmoud Khedr
+- Mohit Davar
+- phoenix-server
+- Radosvet Petrov
+- Sagar
+- Saniddhya Dubey
+- Saransh Sharma
 - Semisol
+- swissrouting
+- Tharupahan Jayawardana
+- Vikash Siwach
+- XD22
+- Yash Agarwal
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -658,7 +658,6 @@ I'm Cameri on most social networks. You can find me on Nostr by npub1qqqqqqyz0la
 - Kushagra Kinra
 - Mahmoud Khedr
 - Mohit Davar
-- phoenix-server
 - Radosvet Petrov
 - Sagar
 - Saniddhya Dubey


### PR DESCRIPTION
Adds all 21 new contributors from the v3.0.0 release to the README contributors list, sorted A-Z.

New contributors added:
- Abhinav Rathee (@abhinavrathee)
- Anshuman (@Anshumancanrock)
- archief2910 (@archief2910)
- Chetan Reddy Kodidela (@CKodidela)
- Divyanshu Kumar (@d1vyanshu-kumar)
- Ferryx (@Ferryx349)
- Kanishka (@kanishka0411)
- Kartik (@kartikangiras)
- Khadar Vali (@khadar1020)
- Khushal (@a-khushal)
- Kushagra Kinra (@kushagra0902)
- Mahmoud Khedr (@Mahmoud-s-Khedr)
- Mohit Davar (@Mohit-Davar)
- phoenix-server (@phoenix-server)
- Radosvet Petrov (@radosvet93)
- Sagar (@sagar-h007)
- Saniddhya Dubey (@saniddhyaDubey)
- Tharupahan Jayawardana (@tharu-jwd)
- Vikash Siwach (@vikashsiwach)
- XD22 (@Justxd22)
- Yash Agarwal (@YashIIT0909)

Existing contributors retained and re-sorted into the full A-Z list.