### PR TITLE
docs: add Abhay and Priyanshu Bharti to contributors list

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,7 @@ I'm Cameri on most social networks. You can find me on Nostr by npub1qqqqqqyz0la
 
 # Contributors (A-Z)
 
+- Abhay
 - Abhinav Rathee
 - André Neves
 - Anshuman
@@ -658,6 +659,7 @@ I'm Cameri on most social networks. You can find me on Nostr by npub1qqqqqqyz0la
 - Kushagra Kinra
 - Mahmoud Khedr
 - Mohit Davar
+- Priyanshu Bharti
 - Radosvet Petrov
 - Sagar
 - Saniddhya Dubey


### PR DESCRIPTION
Adds two contributors who are missing from the README despite having merged commits in the last 3 months:

- **Abhay** (pandeyabhay967@gmail.com) — 4 merged PRs (#624, #625, #627, #628)
- **Priyanshu Bharti** — merged contribution

Both names are inserted in alphabetical order within the existing A-Z list.