### PR TITLE
ci: always update lockfile regardless of whether changeset already exists

### DIFF
--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -64,16 +64,24 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          CHANGED=false
-          if [ -n "$(git status --porcelain pnpm-lock.yaml)" ]; then
-            git add pnpm-lock.yaml
-            CHANGED=true
-          fi
+          ADDED_CHANGESET=false
+          ADDED_LOCKFILE=false
           if [ "${{ steps.check.outputs.exists }}" == 'false' ]; then
             git add ".changeset/dependabot-pr-${{ steps.pr.outputs.number }}.md"
-            CHANGED=true
+            ADDED_CHANGESET=true
           fi
-          if [ "$CHANGED" = true ]; then
-            git commit -m "chore: add changeset and update lockfile for dependabot PR #${{ steps.pr.outputs.number }}"
+          if [ -n "$(git status --porcelain pnpm-lock.yaml)" ]; then
+            git add pnpm-lock.yaml
+            ADDED_LOCKFILE=true
+          fi
+          if [ "$ADDED_CHANGESET" = true ] || [ "$ADDED_LOCKFILE" = true ]; then
+            if [ "$ADDED_CHANGESET" = true ] && [ "$ADDED_LOCKFILE" = true ]; then
+              MSG="chore: add changeset and update lockfile for dependabot PR #${{ steps.pr.outputs.number }}"
+            elif [ "$ADDED_CHANGESET" = true ]; then
+              MSG="chore: add changeset for dependabot PR #${{ steps.pr.outputs.number }}"
+            else
+              MSG="chore: update lockfile for dependabot PR #${{ steps.pr.outputs.number }}"
+            fi
+            git commit -m "$MSG"
             git push
           fi


### PR DESCRIPTION
Follow-up to #656.

When `workflow_dispatch` is run against an existing dependabot PR that already has a changeset, the lockfile should still be updated. Previously the commit was gated on a single `CHANGED` flag that could leave the lockfile uncommitted.

- Tracks `ADDED_CHANGESET` and `ADDED_LOCKFILE` independently
- Commits (and pushes) whenever either is true
- Commit message reflects what was actually added