### PR TITLE
fix: stop hitting additional rate limit windows once a client is already limited

### DIFF
--- a/.changeset/rate-limiter-continues-after-hit.md
+++ b/.changeset/rate-limiter-continues-after-hit.md
@@ -1,0 +1,10 @@
+---
+"nostream": patch
+---
+
+fix: stop checking additional rate limit windows once a client is already rate-limited
+
+`isRateLimited()` in `EventMessageHandler` and `WebSocketAdapter` looped through every
+configured rate limit window even after one had already tripped, calling `rateLimiter.hit()`
+(a Redis write) for each remaining window. Both now return as soon as the first exceeded
+window is found, avoiding redundant Redis writes for clients that are already being limited.

--- a/src/adapters/web-socket-adapter.ts
+++ b/src/adapters/web-socket-adapter.ts
@@ -236,18 +236,17 @@ export class WebSocketAdapter extends EventEmitter implements IWebSocketAdapter 
 
     const hit = (period: number, rate: number) => rateLimiter.hit(`${client}:message:${period}`, 1, { period, rate })
 
-    let limited = false
     for (const { rate, period } of rateLimits) {
       const isRateLimited = await hit(period, rate)
 
       if (isRateLimited) {
         logger('rate limited %s: %d messages / %d ms exceeded', client, rate, period)
 
-        limited = true
+        return true
       }
     }
 
-    return limited
+    return false
   }
 
   private onClientPong() {

--- a/src/handlers/event-message-handler.ts
+++ b/src/handlers/event-message-handler.ts
@@ -351,7 +351,6 @@ export class EventMessageHandler implements IMessageHandler {
       return rateLimiter.hit(key, 1, { period, rate })
     }
 
-    let limited = false
     for (const { rate, period, kinds } of rateLimits) {
       // skip if event kind does not apply
       if (Array.isArray(kinds) && !kinds.some(isEventKindOrRangeMatch(event))) {
@@ -363,11 +362,11 @@ export class EventMessageHandler implements IMessageHandler {
       if (isRateLimited) {
         logger('rate limited %s: %d events / %d ms exceeded', event.pubkey, rate, period)
 
-        limited = true
+        return true
       }
     }
 
-    return limited
+    return false
   }
 
   protected async isUserAdmitted(event: Event): Promise<string | undefined> {

--- a/test/unit/adapters/web-socket-adapter.spec.ts
+++ b/test/unit/adapters/web-socket-adapter.spec.ts
@@ -423,6 +423,34 @@ describe('WebSocketAdapter', () => {
       expect(client.send).to.have.been.called
     })
 
+    it('stops hitting subsequent rate limit windows once one is exceeded', async () => {
+      client.readyState = WebSocket.OPEN
+
+      const hitStub = sandbox.stub().resolves(true)
+
+      settingsFactory.returns({
+        network: { remoteIpHeader: '' },
+        limits: {
+          message: {
+            rateLimits: [
+              { period: 60000, rate: 1 },
+              { period: 180, rate: 3 },
+            ],
+            ipWhitelist: [],
+          },
+        },
+      })
+
+      slidingWindowRateLimiter.returns({ hit: hitStub })
+
+      const messageCall = client.on.getCalls().find((call: any) => call.args[0] === 'message')
+      const onMessage = messageCall.args[1]
+
+      await onMessage(Buffer.from(JSON.stringify(['EVENT', {}])))
+
+      expect(hitStub).to.have.been.calledOnce
+    })
+
     it('does not rate limit when no rateLimits are configured', async () => {
       client.readyState = WebSocket.OPEN
 

--- a/test/unit/handlers/event-message-handler.spec.ts
+++ b/test/unit/handlers/event-message-handler.spec.ts
@@ -1022,6 +1022,26 @@ describe('EventMessageHandler', () => {
       )
       expect(actualResult).to.be.true
     })
+
+    it('stops hitting subsequent rate limit windows once one is exceeded', async () => {
+      eventLimits.rateLimits = [
+        {
+          period: 60000,
+          rate: 1,
+        },
+        {
+          period: 180,
+          rate: 3,
+        },
+      ]
+
+      rateLimiterHitStub.onFirstCall().resolves(true)
+
+      const actualResult = await (handler as any).isRateLimited(event)
+
+      expect(rateLimiterHitStub).to.have.been.calledOnce
+      expect(actualResult).to.be.true
+    })
   })
 
   describe('isUserAdmitted', () => {


### PR DESCRIPTION

## Description
`isRateLimited()` in `EventMessageHandler` (eventetAdapter`
(message rate limiting) looped through every configured rate limit window and called
`rateLimiter.hit()` for each one, even after an eop had
already reported the client as rate-limited. Both methods now `return` as soon as the
first exceeded window is found, instead of continRedis for)
every remaining window.

## Related Issue
Fixes #685

## Motivation and Context
Both `hit()` implementations (`SlidingWindowRateLexecute a Lua script against Redis on every call (a ZADD/HSET write). Once a client is already known to be rate-limited, continuing to hit everypure waste: a burst of messages/events from an already-limited client multiplies Redis writes by the number of configured windows, for no behavioral beturns `true`/rejects the message either way).

## How Has This Been Tested?
- Added a unit test in `test/unit/handlers/event-erting that once the first configured rate limit window reports limited, no further `hit()` calls are made for subsequent windows.
- Added an analogous unit test in `test/unit/adapters/web-socket-adapter.spec.ts` driving the same scenario through the public `onClientMh.
- Ran the full existing unit suites for both files (`pnpm run test:unit`) — all 1395 tests  pass, confirming no existing test relied on thevior.
- Ran `pnpm lint`, `pnpm check:deps`, `pnpm run build`, `pnpm run build:check`,
  `pnpm run verify:cli:build`, `pnpm run test:cli — all pass.
- Ran `pnpm run docker:test:integration` (99 scenarios): 97 passed, including the
  `Rate Limiter` feature
- `pnpm check:format` reports pre-existing formatut the error count is identical with and without this change, and none of the flagged lines are in
  the diff — confirmed against the unmodified bas

## Screenshots (if appropriate):
N/A — backend logic change only.

## Types of changes
- [ ] Non-functional change (docs, style, minor r
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this proj
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingl
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my code changes
- [x] I added a changeset, or this is docs-only and I added an empty changeset.
- [x] All new and existing tests passed.