### PR TITLE
fix: include actual error message in replaceable event rejection responses

### DIFF
--- a/.changeset/replaceable-event-error-message-empty.md
+++ b/.changeset/replaceable-event-error-message-empty.md
@@ -1,0 +1,11 @@
+---
+"nostream": patch
+---
+
+fix: include the actual error message in replaceable event rejection responses
+
+`ReplaceableEventStrategy.execute()` sent clients a bare `error: ` command result
+(with no message body) whenever `eventRepository.upsert()` failed for a reason other
+than a duplicate event id. The underlying `error.message` was caught but never
+included in the response, leaving clients with no actionable information about why
+the event was rejected. The command result now includes `error.message`.

--- a/src/handlers/event-strategies/replaceable-event-strategy.ts
+++ b/src/handlers/event-strategies/replaceable-event-strategy.ts
@@ -32,7 +32,10 @@ export class ReplaceableEventStrategy implements IEventStrategy<Event, Promise<v
           return
         }
 
-        this.webSocket.emit(WebSocketAdapterEvent.Message, createEventCommandResult(event.id, false, 'error: '))
+        this.webSocket.emit(
+          WebSocketAdapterEvent.Message,
+          createEventCommandResult(event.id, false, `error: ${error.message}`),
+        )
       }
     }
   }

--- a/test/unit/handlers/event-strategies/replaceable-event-strategy.spec.ts
+++ b/test/unit/handlers/event-strategies/replaceable-event-strategy.spec.ts
@@ -88,7 +88,7 @@ describe('ReplaceableEventStrategy', () => {
     })
 
     it('rejects if unable to upsert event', async () => {
-      const error = new Error()
+      const error = new Error('connection lost')
       eventRepositoryUpsertStub.rejects(error)
 
       await strategy.execute(event)
@@ -98,7 +98,7 @@ describe('ReplaceableEventStrategy', () => {
         'OK',
         'id',
         false,
-        'error: ',
+        'error: connection lost',
       ])
     })
   })


### PR DESCRIPTION


## Description
`ReplaceableEventStrategy.execute()` sent clients a hardcoded `error: ` command result (trailing space, no message) whenever `eventRepository.upsert()` rejected for any reason other than a duplicate event id constraint violation. The caught `error.message` was never included in the response. The command result now includes `error.message`, e.g. `error: connection refused`.

## Related Issue
https://github.com/Cameri/nostream/issues/710

## Motivation and Context
Clients receiving `["OK", "<id>", false, "error: "]` have no actionable information about why their event was rejected, which makes debugging relay-side failures (DB outages, connection issues, etc.) unnecessarily difficult for client authors and relay operators.

## How Has This Been Tested?

- `pnpm run test:unit` — 1483 passing.
- `pnpm run test:cli` — 73 passing.
- `pnpm run cover:unit` — passing.
- `pnpm run docker:test:integration` — 99 scenarios / 489 steps passing.
- `pnpm run lint`, `pnpm run check:deps`, `pnpm run build:check`, `pnpm run build`,
  `pnpm run verify:cli:build` all pass.

## Screenshots (if appropriate):
N/A — backend WebSocket message content change only.

## Types of changes
- [ ] Non-functional change (docs, style, minor refactor)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my code changes.
- [x] I added a changeset, or this is docs-only and I added an empty changeset.
- [x] All new and existing tests passed.
