### PR TITLE
feat(dvm): add dvm worker registry settings and process topology

### DIFF
--- a/.changeset/dvm-worker-registry.md
+++ b/.changeset/dvm-worker-registry.md
@@ -1,0 +1,5 @@
+---
+"nostream": minor
+---
+
+feat(dvm): add worker registry settings and dvm-orchestrator process topology

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -133,6 +133,10 @@ The settings below are listed in alphabetical order by name. Please keep this ta
 
 | Name                                        | Description                                                                   |
 |---------------------------------------------|-------------------------------------------------------------------------------|
+| dvm.workers[].args                          | Arguments passed to the spawned command. Optional. |
+| dvm.workers[].command                       | Command to spawn for this DVM worker (e.g. an interpreter or executable path). |
+| dvm.workers[].kinds                         | NIP-90 job request kinds (5000-5999) this worker accepts. Optional. |
+| dvm.workers[].timeoutMs                     | Max time in ms to wait for a job result before considering it timed out. Optional. |
 | info.banner                                 | Public banner image URL for the relay information document. |
 | info.contact                                | Relay operator's contact. (e.g. mailto:operator@relay-your-domain.com) |
 | info.description                            | Public description of your relay. (e.g. Toronto Bitcoin Group Public Relay) |

--- a/resources/default-settings.yaml
+++ b/resources/default-settings.yaml
@@ -107,6 +107,8 @@ workers:
   count: 0
 mirroring:
   static: []
+dvm:
+  workers: []
 limits:
   # strategy selection configuration for rate limiting:
   rateLimiter:

--- a/src/@types/settings.ts
+++ b/src/@types/settings.ts
@@ -246,6 +246,21 @@ export interface Mirroring {
   static?: Mirror[]
 }
 
+export interface DvmWorker {
+  /** Command to spawn for this worker (e.g. an interpreter or executable path). */
+  command: string
+  /** Arguments passed to the spawned command. */
+  args?: string[]
+  /** NIP-90 job request kinds (5000-5999) this worker accepts. */
+  kinds?: number[]
+  /** Max time in ms to wait for a job result before considering it timed out. */
+  timeoutMs?: number
+}
+
+export interface Dvm {
+  workers?: DvmWorker[]
+}
+
 export type Nip05Mode = 'enabled' | 'passive' | 'disabled'
 
 export interface Nip45Settings {
@@ -330,6 +345,7 @@ export interface Settings {
   workers?: Worker
   limits?: Limits
   mirroring?: Mirroring
+  dvm?: Dvm
   nip05?: Nip05Settings
   nip42?: Nip42Settings
   nip43?: Nip43Settings

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -108,6 +108,18 @@ export class App implements IRunnable {
       logCentered(`${mirrors.length} static-mirroring worker started`, width)
     }
 
+    const dvmWorkers = settings?.dvm?.workers
+
+    if (Array.isArray(dvmWorkers) && dvmWorkers.length) {
+      for (let i = 0; i < dvmWorkers.length; i++) {
+        createWorker({
+          WORKER_TYPE: 'dvm-orchestrator',
+          DVM_WORKER_INDEX: i.toString(),
+        })
+      }
+      logCentered(`${dvmWorkers.length} dvm-orchestrator worker started`, width)
+    }
+
     logger('settings: %O', settings)
 
     const host = `${hostname()}:${port}`

--- a/src/app/dvm-orchestrator-worker.ts
+++ b/src/app/dvm-orchestrator-worker.ts
@@ -1,0 +1,58 @@
+import { path } from 'ramda'
+import { IRunnable } from '../@types/base'
+import { DvmWorker, Settings } from '../@types/settings'
+import { createLogger } from '../factories/logger-factory'
+import { shutdownMetricsTelemetry } from '../telemetry/metrics'
+
+const logger = createLogger('dvm-orchestrator-worker')
+
+export class DvmOrchestratorWorker implements IRunnable {
+  private config: DvmWorker | undefined
+
+  public constructor(
+    private readonly process: NodeJS.Process,
+    private readonly settings: () => Settings,
+  ) {
+    this.process
+      .on('SIGINT', this.onExit.bind(this))
+      .on('SIGHUP', this.onExit.bind(this))
+      .on('SIGTERM', this.onExit.bind(this))
+      .on('uncaughtException', this.onError.bind(this))
+      .on('unhandledRejection', this.onError.bind(this))
+  }
+
+  public run(): void {
+    const currentSettings = this.settings()
+
+    this.config = path(['dvm', 'workers', this.process.env.DVM_WORKER_INDEX], currentSettings) as DvmWorker | undefined
+
+    if (!this.config) {
+      logger.error('no dvm worker config found for index %s', this.process.env.DVM_WORKER_INDEX)
+      this.process.exit(1)
+      return
+    }
+
+    logger.info('dvm-orchestrator worker started for command: %s', this.config.command)
+  }
+
+  private onError(error: Error) {
+    logger('error: %o', error)
+    throw error
+  }
+
+  private onExit() {
+    logger('exiting')
+    void shutdownMetricsTelemetry().finally(() => {
+      this.close(() => {
+        this.process.exit(0)
+      })
+    })
+  }
+
+  public close(callback?: () => void) {
+    logger('closing')
+    if (typeof callback === 'function') {
+      callback()
+    }
+  }
+}

--- a/src/factories/dvm-orchestrator-worker-factory.ts
+++ b/src/factories/dvm-orchestrator-worker-factory.ts
@@ -1,0 +1,7 @@
+import process from 'process'
+import { DvmOrchestratorWorker } from '../app/dvm-orchestrator-worker'
+import { createSettings } from './settings-factory'
+
+export const dvmOrchestratorWorkerFactory = () => {
+  return new DvmOrchestratorWorker(process, createSettings)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 import cluster from 'cluster'
 
 import { appFactory } from './factories/app-factory'
+import { dvmOrchestratorWorkerFactory } from './factories/dvm-orchestrator-worker-factory'
 import { maintenanceWorkerFactory } from './factories/maintenance-worker-factory'
 import { staticMirroringWorkerFactory } from './factories/static-mirroring.worker-factory'
-import { initializeMetricsTelemetry } from './telemetry/metrics'
 import { workerFactory } from './factories/worker-factory'
+import { initializeMetricsTelemetry } from './telemetry/metrics'
 
 export const getRunner = () => {
   if (cluster.isPrimary) {
@@ -17,6 +18,8 @@ export const getRunner = () => {
         return maintenanceWorkerFactory()
       case 'static-mirroring':
         return staticMirroringWorkerFactory()
+      case 'dvm-orchestrator':
+        return dvmOrchestratorWorkerFactory()
       default:
         throw new Error(`Unknown worker: ${process.env.WORKER_TYPE}`)
     }

--- a/test/unit/app/dvm-orchestrator-worker.spec.ts
+++ b/test/unit/app/dvm-orchestrator-worker.spec.ts
@@ -1,0 +1,87 @@
+import chai from 'chai'
+import EventEmitter from 'events'
+import Sinon from 'sinon'
+import sinonChai from 'sinon-chai'
+
+import { Settings } from '../../../src/@types/settings'
+import { DvmOrchestratorWorker } from '../../../src/app/dvm-orchestrator-worker'
+import * as metricsTelemetry from '../../../src/telemetry/metrics'
+
+chai.use(sinonChai)
+
+const { expect } = chai
+
+describe('DvmOrchestratorWorker', () => {
+  let sandbox: Sinon.SinonSandbox
+  let fakeProcess: EventEmitter & { exit: Sinon.SinonStub; env: Record<string, string> }
+  let settings: Sinon.SinonStub
+  let settingsState: Settings
+
+  beforeEach(() => {
+    sandbox = Sinon.createSandbox()
+
+    fakeProcess = Object.assign(new EventEmitter(), {
+      exit: sandbox.stub(),
+      env: {},
+    }) as EventEmitter & { exit: Sinon.SinonStub; env: Record<string, string> }
+
+    settingsState = {
+      dvm: {
+        workers: [{ command: 'python3', args: ['worker.py'] }],
+      },
+    } as any
+
+    settings = sandbox.stub().callsFake(() => settingsState)
+
+    sandbox.stub(metricsTelemetry, 'shutdownMetricsTelemetry').resolves()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('run', () => {
+    it('logs startup for the worker config at DVM_WORKER_INDEX', () => {
+      fakeProcess.env.DVM_WORKER_INDEX = '0'
+      const worker = new DvmOrchestratorWorker(fakeProcess as any, settings as any)
+
+      expect(() => worker.run()).to.not.throw()
+      expect(fakeProcess.exit).not.to.have.been.called
+    })
+
+    it('exits with code 1 if no worker config exists for the given index', () => {
+      fakeProcess.env.DVM_WORKER_INDEX = '5'
+      const worker = new DvmOrchestratorWorker(fakeProcess as any, settings as any)
+
+      worker.run()
+
+      expect(fakeProcess.exit).to.have.been.calledWith(1)
+    })
+  })
+
+  describe('signal handling', () => {
+    it('closes and exits on SIGTERM', async () => {
+      fakeProcess.env.DVM_WORKER_INDEX = '0'
+      const worker = new DvmOrchestratorWorker(fakeProcess as any, settings as any)
+      worker.run()
+
+      fakeProcess.emit('SIGTERM')
+
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(fakeProcess.exit).to.have.been.calledWith(0)
+    })
+  })
+
+  describe('close', () => {
+    it('invokes the callback', () => {
+      const worker = new DvmOrchestratorWorker(fakeProcess as any, settings as any)
+      const callback = sandbox.stub()
+
+      worker.close(callback)
+
+      expect(callback).to.have.been.calledOnce
+    })
+  })
+})

--- a/test/unit/factories/dvm-orchestrator-worker-factory.spec.ts
+++ b/test/unit/factories/dvm-orchestrator-worker-factory.spec.ts
@@ -1,0 +1,10 @@
+import { expect } from 'chai'
+
+import { DvmOrchestratorWorker } from '../../../src/app/dvm-orchestrator-worker'
+import { dvmOrchestratorWorkerFactory } from '../../../src/factories/dvm-orchestrator-worker-factory'
+
+describe('dvmOrchestratorWorkerFactory', () => {
+  it('returns a DvmOrchestratorWorker', () => {
+    expect(dvmOrchestratorWorkerFactory()).to.be.an.instanceOf(DvmOrchestratorWorker)
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds the worker registry and process topology needed before the relay can route NIP-90 DVM jobs to external worker processes. This is a foundation/skeleton PR - no job ingestion or IPC dispatch yet.

- Adds a `dvm:` settings section (`Dvm` / `DvmWorker` types in `src/@types/settings.ts`, default `dvm: workers: []` in `resources/default-settings.yaml`) so operators can register DVM workers (command, args, accepted job kinds, timeout), following the exact same shape as the existing  `mirroring.static` list-of-configs convention.
- Wires a new `WORKER_TYPE=dvm-orchestrator` process type into the cluster topology:  `App.run()` forks one process per configured `dvm.workers[]` entry (mirroring the existing `mirroring.static` fork loop), and `src/index.ts`'s `getRunner()` dispatches to a new factory.
- Adds a skeleton `DvmOrchestratorWorker` (`src/app/dvm-orchestrator-worker.ts`) implementing the repo's `IRunnable` interface: reads its assigned config via `DVM_WORKER_INDEX`, wires standard
  SIGINT/SIGHUP/SIGTERM/uncaughtException/unhandledRejection handling matching
  `MaintenanceWorker`/`StaticMirroringWorker`, and exits non-zero if no config is found for its index. It does not spawn or dispatch jobs yet.
- Documents the new `dvm.workers[]` settings in `CONFIGURATION.md`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Part of #639

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Nostream has no support for Data Vending Machines (NIP-90) today. The DVM kind range (5000-6999) is used in production by real services despite the NIP's `unrecommended` status upstream, so the relay needs to handle these events properly. Before job routing, lifecycle tracking, or IPC dispatch can be built, the relay needs a place for operators to register available DVM workers and a process topology to run them in — that's what this PR adds. Job ingestion (trapping kind 5000-5999 events) and IPC dispatch (spawning workers, sending jobs, publishing results) are separate, independently reviewable follow-up PRs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added unit tests for `DvmOrchestratorWorker` (startup with a valid config, exit(1) when no config exists for the assigned index, signal handling on SIGTERM, `close()` callback invocation) and for `dvmOrchestratorWorkerFactory`  5 new tests total, following the existing `MaintenanceWorker`/`maintenanceWorkerFactory` test conventions (Sinon-stubbed `process` EventEmitter, stubbed settings function).
- Ran the full local CI suite:
  - `pnpm exec commitlint --from=upstream/main --to=HEAD`
  - `pnpm exec changeset status --since upstream/main`
  - `pnpm lint`, `pnpm check:format` (touched files), `pnpm check:deps`
  - `pnpm run build:check`, `pnpm run build`, `pnpm run verify:cli:build`
  - `pnpm run test:unit` — 1505 passing
  - `pnpm run test:cli` — 73 passing
  - `pnpm run cover:unit` — new files at 91.66%/100% coverage
  - `pnpm run docker:test:integration` — 99 scenarios / 489 steps passing (ran this despite the
    change being additive, since it touches the primary process's fork loop in `app.ts` and the
    `WORKER_TYPE` dispatch in `index.ts`)
- Manually verified `dvm.workers` defaults to `[]`, so no `dvm-orchestrator` workers are forked and existing topology (client workers, maintenance worker, static-mirroring workers) is unaffected unless an operator explicitly configures `dvm.workers`.

## Screenshots (if appropriate):
N/A — process topology / settings change, no UI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Non-functional change (docs, style, minor refactor)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my code changes.
- [x] I added a changeset, or this is docs-only and I added an empty changeset.
- [x] All new and existing tests passed.
