### PR TITLE
feat(dvm): trap NIP-90 job request events and record them via job repository

### DIFF
--- a/.changeset/dvm-job-ingestion.md
+++ b/.changeset/dvm-job-ingestion.md
@@ -1,0 +1,5 @@
+---
+"nostream": minor
+---
+
+feat(dvm): trap NIP-90 job request events (kind 5000-5999) and record them via the job repository

--- a/.knip.json
+++ b/.knip.json
@@ -16,7 +16,6 @@
   ],
   "ignore": [
     ".nostr/**",
-    "src/repositories/dvm-job-repository.ts",
     "src/utils/relay-probe/**"
   ],
   "commitlint": false,

--- a/src/constants/base.ts
+++ b/src/constants/base.ts
@@ -41,6 +41,9 @@ export enum EventKinds {
   // Lightning zaps
   ZAP_REQUEST = 9734,
   ZAP_RECEIPT = 9735,
+  // NIP-90: Data Vending Machines — job request events
+  DVM_JOB_REQUEST_FIRST = 5000,
+  DVM_JOB_REQUEST_LAST = 5999,
   // Replaceable events
   REPLACEABLE_FIRST = 10000,
   // NIP-65: Relay List Metadata

--- a/src/factories/event-strategy-factory.ts
+++ b/src/factories/event-strategy-factory.ts
@@ -1,7 +1,8 @@
 import { ICacheAdapter, IWebSocketAdapter } from '../@types/adapters'
-import { IEventRepository, IInviteCodeRepository, IUserRepository } from '../@types/repositories'
+import { IDvmJobRepository, IEventRepository, IInviteCodeRepository, IUserRepository } from '../@types/repositories'
 import {
   isDeleteEvent,
+  isDvmJobRequestEvent,
   isEphemeralEvent,
   isGiftWrapEvent,
   isMarmotGroupEvent,
@@ -14,6 +15,7 @@ import { isNip43JoinRequest, isNip43LeaveRequest } from '../utils/nip43'
 import { isRelayListEvent } from '../utils/nip65'
 import { DefaultEventStrategy } from '../handlers/event-strategies/default-event-strategy'
 import { DeleteEventStrategy } from '../handlers/event-strategies/delete-event-strategy'
+import { DvmJobRequestEventStrategy } from '../handlers/event-strategies/dvm-job-request-event-strategy'
 import { EphemeralEventStrategy } from '../handlers/event-strategies/ephemeral-event-strategy'
 import { Event } from '../@types/event'
 import { Factory } from '../@types/base'
@@ -33,6 +35,7 @@ export const eventStrategyFactory =
     eventRepository: IEventRepository,
     userRepository: IUserRepository,
     inviteCodeRepository: IInviteCodeRepository,
+    dvmJobRepository: IDvmJobRepository,
     cache: ICacheAdapter,
     settings: () => Settings,
   ): Factory<IEventStrategy<Event, Promise<void>>, [Event, IWebSocketAdapter]> =>
@@ -47,12 +50,17 @@ export const eventStrategyFactory =
       return new TimestampEventStrategy(adapter, eventRepository)
     } else if (isRelayListEvent(event) || isReplaceableEvent(event)) {
       return new ReplaceableEventStrategy(adapter, eventRepository)
-    // NIP-43: Join/Leave requests MUST be checked before the generic ephemeral
-    // handler, because kinds 28934/28936 fall in the ephemeral range (20000-29999).
+      // NIP-43: Join/Leave requests MUST be checked before the generic ephemeral
+      // handler, because kinds 28934/28936 fall in the ephemeral range (20000-29999).
     } else if (isNip43JoinRequest(event)) {
       return new JoinRequestEventStrategy(adapter, inviteCodeRepository, userRepository, cache, settings)
     } else if (isNip43LeaveRequest(event)) {
       return new LeaveRequestEventStrategy(adapter, userRepository, cache, settings)
+      // NIP-90: DVM job requests (kind 5000-5999) checked early, same reasoning
+      // as the NIP-43 checks above — kept explicit rather than relying on it
+      // falling through to DefaultEventStrategy.
+    } else if (isDvmJobRequestEvent(event)) {
+      return new DvmJobRequestEventStrategy(adapter, eventRepository, dvmJobRepository)
     } else if (isEphemeralEvent(event)) {
       return new EphemeralEventStrategy(adapter)
     } else if (isDeleteEvent(event)) {

--- a/src/factories/message-handler-factory.ts
+++ b/src/factories/message-handler-factory.ts
@@ -1,5 +1,11 @@
 import { ICacheAdapter, IWebSocketAdapter } from '../@types/adapters'
-import { IEventRepository, IInviteCodeRepository, INip05VerificationRepository, IUserRepository } from '../@types/repositories'
+import {
+  IDvmJobRepository,
+  IEventRepository,
+  IInviteCodeRepository,
+  INip05VerificationRepository,
+  IUserRepository,
+} from '../@types/repositories'
 import { IncomingMessage, MessageType } from '../@types/messages'
 import { createSettings } from './settings-factory'
 import { AuthMessageHandler } from '../handlers/auth-message-handler'
@@ -26,13 +32,21 @@ export const messageHandlerFactory =
     userRepository: IUserRepository,
     nip05VerificationRepository: INip05VerificationRepository,
     inviteCodeRepository: IInviteCodeRepository,
+    dvmJobRepository: IDvmJobRepository,
   ) =>
   ([message, adapter]: [IncomingMessage, IWebSocketAdapter]) => {
     switch (message[0]) {
       case MessageType.EVENT: {
         return new EventMessageHandler(
           adapter,
-          eventStrategyFactory(eventRepository, userRepository, inviteCodeRepository, getCache(), createSettings),
+          eventStrategyFactory(
+            eventRepository,
+            userRepository,
+            inviteCodeRepository,
+            dvmJobRepository,
+            getCache(),
+            createSettings,
+          ),
           eventRepository,
           userRepository,
           createSettings,

--- a/src/factories/websocket-adapter-factory.ts
+++ b/src/factories/websocket-adapter-factory.ts
@@ -1,7 +1,13 @@
 import { IncomingMessage } from 'http'
 import { WebSocket } from 'ws'
 
-import { IEventRepository, IInviteCodeRepository, INip05VerificationRepository, IUserRepository } from '../@types/repositories'
+import {
+  IDvmJobRepository,
+  IEventRepository,
+  IInviteCodeRepository,
+  INip05VerificationRepository,
+  IUserRepository,
+} from '../@types/repositories'
 import { createSettings } from './settings-factory'
 import { IWebSocketServerAdapter } from '../@types/adapters'
 import { messageHandlerFactory } from './message-handler-factory'
@@ -14,13 +20,20 @@ export const webSocketAdapterFactory =
     userRepository: IUserRepository,
     nip05VerificationRepository: INip05VerificationRepository,
     inviteCodeRepository: IInviteCodeRepository,
+    dvmJobRepository: IDvmJobRepository,
   ) =>
   ([client, request, webSocketServerAdapter]: [WebSocket, IncomingMessage, IWebSocketServerAdapter]) =>
     new WebSocketAdapter(
       client,
       request,
       webSocketServerAdapter,
-      messageHandlerFactory(eventRepository, userRepository, nip05VerificationRepository, inviteCodeRepository),
+      messageHandlerFactory(
+        eventRepository,
+        userRepository,
+        nip05VerificationRepository,
+        inviteCodeRepository,
+        dvmJobRepository,
+      ),
       rateLimiterFactory,
       createSettings,
     )

--- a/src/factories/worker-factory.ts
+++ b/src/factories/worker-factory.ts
@@ -8,6 +8,7 @@ import { AppWorker } from '../app/worker'
 import { createLogger } from './logger-factory'
 import { createSettings } from '../factories/settings-factory'
 import { createWebApp } from './web-app-factory'
+import { DvmJobRepository } from '../repositories/dvm-job-repository'
 import { EventRepository } from '../repositories/event-repository'
 import { InviteCodeRepository } from '../repositories/invite-code-repository'
 import { Nip05VerificationRepository } from '../repositories/nip05-verification-repository'
@@ -24,6 +25,7 @@ export const workerFactory = (): AppWorker => {
   const userRepository = new UserRepository(dbClient, eventRepository)
   const nip05VerificationRepository = new Nip05VerificationRepository(dbClient)
   const inviteCodeRepository = new InviteCodeRepository(dbClient)
+  const dvmJobRepository = new DvmJobRepository(dbClient)
 
   const settings = createSettings()
 
@@ -65,7 +67,13 @@ export const workerFactory = (): AppWorker => {
   const adapter = new WebSocketServerAdapter(
     server,
     webSocketServer,
-    webSocketAdapterFactory(eventRepository, userRepository, nip05VerificationRepository, inviteCodeRepository),
+    webSocketAdapterFactory(
+      eventRepository,
+      userRepository,
+      nip05VerificationRepository,
+      inviteCodeRepository,
+      dvmJobRepository,
+    ),
     createSettings,
   )
 

--- a/src/handlers/event-strategies/dvm-job-request-event-strategy.ts
+++ b/src/handlers/event-strategies/dvm-job-request-event-strategy.ts
@@ -1,0 +1,42 @@
+import { createEventCommandResult } from '../../telemetry/event-metrics'
+import { createLogger } from '../../factories/logger-factory'
+import { Event } from '../../@types/event'
+import { IDvmJobRepository, IEventRepository } from '../../@types/repositories'
+import { IEventStrategy } from '../../@types/message-handlers'
+import { IWebSocketAdapter } from '../../@types/adapters'
+import { WebSocketAdapterEvent } from '../../constants/adapter'
+
+const logger = createLogger('dvm-job-request-event-strategy')
+
+export class DvmJobRequestEventStrategy implements IEventStrategy<Event, Promise<void>> {
+  public constructor(
+    private readonly webSocket: IWebSocketAdapter,
+    private readonly eventRepository: IEventRepository,
+    private readonly dvmJobRepository: IDvmJobRepository,
+  ) {}
+
+  public async execute(event: Event): Promise<void> {
+    logger('received dvm job request: %o', event)
+
+    const count = await this.eventRepository.create(event)
+    this.webSocket.emit(
+      WebSocketAdapterEvent.Message,
+      createEventCommandResult(event.id, true, count ? '' : 'duplicate:'),
+    )
+
+    if (!count) {
+      return
+    }
+
+    this.webSocket.emit(WebSocketAdapterEvent.Broadcast, event)
+
+    try {
+      await this.dvmJobRepository.create(event.id, event.pubkey, event.kind)
+    } catch (error) {
+      // Job-state recording is best-effort: the event itself is already
+      // stored and broadcast correctly, so a repository failure here must
+      // not surface as a rejection of a valid event.
+      logger.error('unable to record dvm job for event %s: %o', event.id, error)
+    }
+  }
+}

--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -40,18 +40,20 @@ export const isEventMatchingFilter =
   (filter: SubscriptionFilter) =>
   (event: Event): boolean => {
     const startsWith = (input: string) => (prefix: string) => input.startsWith(prefix)
-    const isMatchingGenericTagCriterion = (key: string, criterion: string) => (tag: Tag): boolean => {
-      const [, tagName] = key
-      if (tag[0] !== tagName) {
-        return false
-      }
+    const isMatchingGenericTagCriterion =
+      (key: string, criterion: string) =>
+      (tag: Tag): boolean => {
+        const [, tagName] = key
+        if (tag[0] !== tagName) {
+          return false
+        }
 
-      if (isGeohashPrefixCriterion(key, criterion)) {
-        return tag[1].startsWith(stripGeohashPrefixWildcard(criterion))
-      }
+        if (isGeohashPrefixCriterion(key, criterion)) {
+          return tag[1].startsWith(stripGeohashPrefixWildcard(criterion))
+        }
 
-      return tag[1] === criterion
-    }
+        return tag[1] === criterion
+      }
 
     // NIP-01: Basic protocol flow description
 
@@ -96,7 +98,9 @@ export const isEventMatchingFilter =
       Object.entries(filter)
         .filter(([key, criteria]) => isGenericTagQuery(key) && Array.isArray(criteria))
         .some(([key, criteria]) => {
-          return !event.tags.some((tag) => criteria.some((criterion) => isMatchingGenericTagCriterion(key, criterion)(tag)))
+          return !event.tags.some((tag) =>
+            criteria.some((criterion) => isMatchingGenericTagCriterion(key, criterion)(tag)),
+          )
         })
     ) {
       return false
@@ -203,6 +207,10 @@ export const isReplaceableEvent = (event: Event): boolean => {
 
 export const isEphemeralEvent = (event: Event): boolean => {
   return event.kind >= EventKinds.EPHEMERAL_FIRST && event.kind <= EventKinds.EPHEMERAL_LAST
+}
+
+export const isDvmJobRequestEvent = (event: Event): boolean => {
+  return event.kind >= EventKinds.DVM_JOB_REQUEST_FIRST && event.kind <= EventKinds.DVM_JOB_REQUEST_LAST
 }
 
 export const isParameterizedReplaceableEvent = (event: Event): boolean => {

--- a/test/unit/factories/event-strategy-factory.spec.ts
+++ b/test/unit/factories/event-strategy-factory.spec.ts
@@ -1,8 +1,14 @@
 import { expect } from 'chai'
 
-import { IEventRepository, IInviteCodeRepository, IUserRepository } from '../../../src/@types/repositories'
+import {
+  IDvmJobRepository,
+  IEventRepository,
+  IInviteCodeRepository,
+  IUserRepository,
+} from '../../../src/@types/repositories'
 import { DefaultEventStrategy } from '../../../src/handlers/event-strategies/default-event-strategy'
 import { DeleteEventStrategy } from '../../../src/handlers/event-strategies/delete-event-strategy'
+import { DvmJobRequestEventStrategy } from '../../../src/handlers/event-strategies/dvm-job-request-event-strategy'
 import { EphemeralEventStrategy } from '../../../src/handlers/event-strategies/ephemeral-event-strategy'
 import { Event } from '../../../src/@types/event'
 import { EventKinds } from '../../../src/constants/base'
@@ -24,6 +30,7 @@ describe('eventStrategyFactory', () => {
   let eventRepository: IEventRepository
   let userRepository: IUserRepository
   let inviteCodeRepository: IInviteCodeRepository
+  let dvmJobRepository: IDvmJobRepository
   let cache: ICacheAdapter
   let settings: () => Settings
   let event: Event
@@ -34,12 +41,20 @@ describe('eventStrategyFactory', () => {
     eventRepository = {} as any
     userRepository = {} as any
     inviteCodeRepository = {} as any
+    dvmJobRepository = {} as any
     cache = {} as any
-    settings = () => ({ info: { relay_url: 'wss://test.relay' } } as any)
+    settings = () => ({ info: { relay_url: 'wss://test.relay' } }) as any
     event = {} as any
     adapter = {} as any
 
-    factory = eventStrategyFactory(eventRepository, userRepository, inviteCodeRepository, cache, settings)
+    factory = eventStrategyFactory(
+      eventRepository,
+      userRepository,
+      inviteCodeRepository,
+      dvmJobRepository,
+      cache,
+      settings,
+    )
   })
 
   it('returns ReplaceableEvent given a set_metadata event', () => {
@@ -135,5 +150,15 @@ describe('eventStrategyFactory', () => {
   it('returns LeaveRequestEventStrategy given a NIP-43 leave request (kind 28936)', () => {
     event.kind = EventKinds.NIP43_LEAVE_REQUEST
     expect(factory([event, adapter])).to.be.an.instanceOf(LeaveRequestEventStrategy)
+  })
+
+  it('returns DvmJobRequestEventStrategy given a DVM job request (kind 5000-5999)', () => {
+    event.kind = EventKinds.DVM_JOB_REQUEST_FIRST
+    expect(factory([event, adapter])).to.be.an.instanceOf(DvmJobRequestEventStrategy)
+  })
+
+  it('returns DvmJobRequestEventStrategy given the last DVM job request kind (5999)', () => {
+    event.kind = EventKinds.DVM_JOB_REQUEST_LAST
+    expect(factory([event, adapter])).to.be.an.instanceOf(DvmJobRequestEventStrategy)
   })
 })

--- a/test/unit/factories/message-handler-factory.spec.ts
+++ b/test/unit/factories/message-handler-factory.spec.ts
@@ -1,6 +1,12 @@
 import { expect } from 'chai'
 
-import { IEventRepository, IInviteCodeRepository, INip05VerificationRepository, IUserRepository } from '../../../src/@types/repositories'
+import {
+  IDvmJobRepository,
+  IEventRepository,
+  IInviteCodeRepository,
+  INip05VerificationRepository,
+  IUserRepository,
+} from '../../../src/@types/repositories'
 import { IncomingMessage, MessageType } from '../../../src/@types/messages'
 import { AuthMessageHandler } from '../../../src/handlers/auth-message-handler'
 import { Event } from '../../../src/@types/event'
@@ -19,6 +25,7 @@ describe('messageHandlerFactory', () => {
   let userRepository: IUserRepository
   let nip05VerificationRepository: INip05VerificationRepository
   let inviteCodeRepository: IInviteCodeRepository
+  let dvmJobRepository: IDvmJobRepository
   let message: IncomingMessage
   let adapter: IWebSocketAdapter
   let factory
@@ -42,11 +49,18 @@ describe('messageHandlerFactory', () => {
     userRepository = {} as any
     nip05VerificationRepository = {} as any
     inviteCodeRepository = {} as any
+    dvmJobRepository = {} as any
     adapter = {} as any
     event = {
       tags: [],
     } as any
-    factory = messageHandlerFactory(eventRepository, userRepository, nip05VerificationRepository, inviteCodeRepository)
+    factory = messageHandlerFactory(
+      eventRepository,
+      userRepository,
+      nip05VerificationRepository,
+      inviteCodeRepository,
+      dvmJobRepository,
+    )
   })
 
   afterEach(() => {
@@ -89,4 +103,3 @@ describe('messageHandlerFactory', () => {
     expect(() => factory([message, adapter])).to.throw(Error, 'Unknown message type: undefined')
   })
 })
-

--- a/test/unit/factories/websocket-adapter-factory.spec.ts
+++ b/test/unit/factories/websocket-adapter-factory.spec.ts
@@ -3,7 +3,13 @@ import { IncomingMessage } from 'http'
 import Sinon from 'sinon'
 import WebSocket from 'ws'
 
-import { IEventRepository, IInviteCodeRepository, INip05VerificationRepository, IUserRepository } from '../../../src/@types/repositories'
+import {
+  IDvmJobRepository,
+  IEventRepository,
+  IInviteCodeRepository,
+  INip05VerificationRepository,
+  IUserRepository,
+} from '../../../src/@types/repositories'
 import { IWebSocketServerAdapter } from '../../../src/@types/adapters'
 import { SettingsStatic } from '../../../src/utils/settings'
 import { WebSocketAdapter } from '../../../src/adapters/web-socket-adapter'
@@ -33,6 +39,7 @@ describe('webSocketAdapterFactory', () => {
     const userRepository: IUserRepository = {} as any
     const nip05VerificationRepository: INip05VerificationRepository = {} as any
     const inviteCodeRepository: IInviteCodeRepository = {} as any
+    const dvmJobRepository: IDvmJobRepository = {} as any
 
     const client: WebSocket = {
       on: onStub,
@@ -48,7 +55,13 @@ describe('webSocketAdapterFactory', () => {
     } as any
     const webSocketServerAdapter: IWebSocketServerAdapter = {} as any
 
-    const factory = webSocketAdapterFactory(eventRepository, userRepository, nip05VerificationRepository, inviteCodeRepository)
+    const factory = webSocketAdapterFactory(
+      eventRepository,
+      userRepository,
+      nip05VerificationRepository,
+      inviteCodeRepository,
+      dvmJobRepository,
+    )
     expect(factory([client, request, webSocketServerAdapter])).to.be.an.instanceOf(WebSocketAdapter)
   })
 })

--- a/test/unit/handlers/event-strategies/dvm-job-request-event-strategy.spec.ts
+++ b/test/unit/handlers/event-strategies/dvm-job-request-event-strategy.spec.ts
@@ -1,0 +1,132 @@
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import Sinon from 'sinon'
+
+chai.use(chaiAsPromised)
+
+const { expect } = chai
+
+import { DvmJobRequestEventStrategy } from '../../../../src/handlers/event-strategies/dvm-job-request-event-strategy'
+import { Event } from '../../../../src/@types/event'
+import { IDvmJobRepository, IEventRepository } from '../../../../src/@types/repositories'
+import { IEventStrategy } from '../../../../src/@types/message-handlers'
+import { IWebSocketAdapter } from '../../../../src/@types/adapters'
+import { MessageType } from '../../../../src/@types/messages'
+import { WebSocketAdapterEvent } from '../../../../src/constants/adapter'
+
+describe('DvmJobRequestEventStrategy', () => {
+  const event: Event = {
+    id: 'event-id',
+    pubkey: 'requester-pubkey',
+    kind: 5000,
+  } as any
+
+  let webSocket: IWebSocketAdapter
+  let eventRepository: IEventRepository
+  let dvmJobRepository: IDvmJobRepository
+
+  let webSocketEmitStub: Sinon.SinonStub
+  let eventRepositoryCreateStub: Sinon.SinonStub
+  let dvmJobRepositoryCreateStub: Sinon.SinonStub
+
+  let strategy: IEventStrategy<Event, Promise<void>>
+
+  let sandbox: Sinon.SinonSandbox
+
+  beforeEach(() => {
+    sandbox = Sinon.createSandbox()
+
+    webSocketEmitStub = sandbox.stub()
+    webSocket = {
+      emit: webSocketEmitStub,
+    } as any
+
+    eventRepositoryCreateStub = sandbox.stub()
+    eventRepository = {
+      create: eventRepositoryCreateStub,
+    } as any
+
+    dvmJobRepositoryCreateStub = sandbox.stub()
+    dvmJobRepository = {
+      create: dvmJobRepositoryCreateStub,
+    } as any
+
+    strategy = new DvmJobRequestEventStrategy(webSocket, eventRepository, dvmJobRepository)
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('execute', () => {
+    it('creates the event', async () => {
+      eventRepositoryCreateStub.resolves(1)
+      dvmJobRepositoryCreateStub.resolves({})
+
+      await strategy.execute(event)
+
+      expect(eventRepositoryCreateStub).to.have.been.calledOnceWithExactly(event)
+    })
+
+    it('records a dvm job when the event is newly created', async () => {
+      eventRepositoryCreateStub.resolves(1)
+      dvmJobRepositoryCreateStub.resolves({})
+
+      await strategy.execute(event)
+
+      expect(dvmJobRepositoryCreateStub).to.have.been.calledOnceWithExactly('event-id', 'requester-pubkey', 5000)
+    })
+
+    it('broadcasts the event when newly created', async () => {
+      eventRepositoryCreateStub.resolves(1)
+      dvmJobRepositoryCreateStub.resolves({})
+
+      await strategy.execute(event)
+
+      expect(webSocketEmitStub).to.have.been.calledWithExactly(WebSocketAdapterEvent.Message, [
+        MessageType.OK,
+        'event-id',
+        true,
+        '',
+      ])
+      expect(webSocketEmitStub).to.have.been.calledWithExactly(WebSocketAdapterEvent.Broadcast, event)
+    })
+
+    it('does not broadcast or record a job when the event is a duplicate', async () => {
+      eventRepositoryCreateStub.resolves(0)
+
+      await strategy.execute(event)
+
+      expect(webSocketEmitStub).to.have.been.calledOnceWithExactly(WebSocketAdapterEvent.Message, [
+        MessageType.OK,
+        'event-id',
+        true,
+        'duplicate:',
+      ])
+      expect(dvmJobRepositoryCreateStub).not.to.have.been.called
+    })
+
+    it('does not reject the event when job recording fails', async () => {
+      eventRepositoryCreateStub.resolves(1)
+      dvmJobRepositoryCreateStub.rejects(new Error('db unavailable'))
+
+      await expect(strategy.execute(event)).to.eventually.be.fulfilled
+
+      expect(webSocketEmitStub).to.have.been.calledWithExactly(WebSocketAdapterEvent.Message, [
+        MessageType.OK,
+        'event-id',
+        true,
+        '',
+      ])
+    })
+
+    it('rejects if unable to create the event', async () => {
+      const error = new Error('event creation failed')
+      eventRepositoryCreateStub.rejects(error)
+
+      await expect(strategy.execute(event)).to.eventually.be.rejectedWith(error)
+
+      expect(dvmJobRepositoryCreateStub).not.to.have.been.called
+    })
+  })
+})

--- a/test/unit/utils/event.spec.ts
+++ b/test/unit/utils/event.spec.ts
@@ -4,6 +4,7 @@ import {
   getEventExpiration,
   isDeleteEvent,
   isDirectMessageEvent,
+  isDvmJobRequestEvent,
   isEphemeralEvent,
   isEventIdValid,
   isEventMatchingFilter,
@@ -413,6 +414,24 @@ describe('NIP-16', () => {
 
     it('returns false if event is not replaceable', () => {
       expect(isEphemeralEvent({ kind: 30000 } as any)).to.be.false
+    })
+  })
+
+  describe('isDvmJobRequestEvent', () => {
+    it('returns true for the first kind in the DVM job request range (5000)', () => {
+      expect(isDvmJobRequestEvent({ kind: 5000 } as any)).to.be.true
+    })
+
+    it('returns true for the last kind in the DVM job request range (5999)', () => {
+      expect(isDvmJobRequestEvent({ kind: 5999 } as any)).to.be.true
+    })
+
+    it('returns false for a kind below the DVM job request range', () => {
+      expect(isDvmJobRequestEvent({ kind: 4999 } as any)).to.be.false
+    })
+
+    it('returns false for a kind above the DVM job request range', () => {
+      expect(isDvmJobRequestEvent({ kind: 6000 } as any)).to.be.false
     })
   })
 })


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail -->
Adds ingestion for NIP-90 DVM job request events (kind 5000-5999): the relay now recognizes these events, stores and broadcasts them like any other event, and records job state via the `DvmJobRepository` added in #727. No worker dispatch yet  that's a separate follow-up PR.

- Added `EventKinds.DVM_JOB_REQUEST_FIRST`/`DVM_JOB_REQUEST_LAST` (5000/5999) to  `src/constants/base.ts`, and `isDvmJobRequestEvent()` to `src/utils/event.ts`, following the  same range-check pattern as `isEphemeralEvent`/`isParameterizedReplaceableEvent`.
- New `DvmJobRequestEventStrategy` (`src/handlers/event-strategies/dvm-job-request-event-strategy.ts`):
  stores the event via `eventRepository.create()` and broadcasts it (job request events are still regular Nostr events, so clients/DVMs can query them normally), then records job state via `dvmJobRepository.create(id, pubkey, kind)` as a best-effort side effect — a job-repository failure is logged but never causes a valid event to be rejected.
- Wired into `eventStrategyFactory`, checked early alongside the existing NIP-43 checks.
- Threaded `IDvmJobRepository` through the factory chain that constructs the strategy:
  `worker-factory.ts` (constructs `DvmJobRepository`) → `websocket-adapter-factory.ts` →
  `message-handler-factory.ts` → `event-strategy-factory.ts`.
- Removed `src/repositories/dvm-job-repository.ts` from `.knip.json`'s ignore list — it now has a
  real consumer, so the temporary entry added in #727 is no longer needed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #728, part of #639

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Kind 5000-5999 currently falls outside every existing event-kind range constant, so DVM jobrequests silently land in  `DefaultEventStrategy` and are treated as plain events — no job state is tracked at all. This PR adds recognition and job-state recording so the persistence layer added in #727 actually gets populated, without yet building the IPC dispatch logic that consumes it (kept separate to avoid a large, hard-to-review PR).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- New tests for `isDvmJobRequestEvent` (range boundaries), `DvmJobRequestEventStrategy` (event  creation, job recording, broadcast behavior, duplicate handling, and that a job-repository  failure doesn't reject the event), and `eventStrategyFactory` (dispatches to the new strategy for kind 5000 and 5999). Updated the four factory test files whose constructor signatures changed to thread the new repository through.
- Ran the full local CI suite: `pnpm lint`, `pnpm check:format`, `pnpm check:deps`,
  `pnpm run build:check`, `pnpm run build`, `pnpm run test:unit` (1576 passing), `pnpm run cover:unit`,
  `pnpm run docker:test:integration` (99 scenarios / 489 steps passing).

## Screenshots (if appropriate):
N/A — event ingestion change, no UI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Non-functional change (docs, style, minor refactor)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my code changes.
- [x] I added a changeset, or this is docs-only and I added an empty changeset.
- [x] All new and existing tests passed.
