### PR TITLE
fix(cli): stop info command from hanging when database is unreachable

### DIFF
--- a/.changeset/fix-cli-info-event-count-hang.md
+++ b/.changeset/fix-cli-info-event-count-hang.md
@@ -1,0 +1,5 @@
+---
+"nostream": patch
+---
+
+fix(cli): stop `nostream info` from hanging indefinitely when the database is unreachable

--- a/src/cli/commands/info.ts
+++ b/src/cli/commands/info.ts
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import knex from 'knex'
+import { Client } from 'pg'
 
 import packageJson from '../../../package.json'
 import { loadMergedSettings } from '../utils/config'
@@ -24,34 +24,36 @@ type I2PGuidancePayload = {
 }
 
 const getEventCount = async (): Promise<number | null> => {
-  const db = knex({
-    client: 'pg',
-    connection: process.env.DB_URI
-      ? process.env.DB_URI
+  // Uses a raw pg.Client (connect/query/end) rather than a knex pool: when the
+  // connection attempt itself times out, knex/tarn's pool can leave the
+  // underlying socket open (never disposed), which keeps this one-shot CLI
+  // process alive indefinitely. pg.Client.end() reliably closes the socket
+  // even on a failed/timed-out connect, so the process can exit normally.
+  const client = new Client(
+    process.env.DB_URI
+      ? { connectionString: process.env.DB_URI, connectionTimeoutMillis: 1000 }
       : {
           host: process.env.DB_HOST,
           port: Number(process.env.DB_PORT),
           user: process.env.DB_USER,
           password: process.env.DB_PASSWORD,
           database: process.env.DB_NAME,
+          connectionTimeoutMillis: 1000,
         },
-    pool: {
-      min: 0,
-      max: 1,
-      idleTimeoutMillis: 1000,
-      acquireTimeoutMillis: 1000,
-      propagateCreateError: false,
-    },
-    acquireConnectionTimeout: 1000,
-  } as any)
+  )
 
   try {
-    const result = await db('events').whereNull('deleted_at').count<{ count: string | number }>('* as count').first()
-    return Number(result?.count ?? 0)
+    await client.connect()
+    const result = await client.query('select count(*) as count from events where deleted_at is null')
+    return Number(result.rows[0]?.count ?? 0)
   } catch {
     return null
   } finally {
-    await db.destroy()
+    try {
+      await client.end()
+    } catch {
+      // already disconnected/never connected — nothing to clean up
+    }
   }
 }
 
@@ -66,9 +68,13 @@ const getRelayUptimeSeconds = async (): Promise<number | null> => {
     return null
   }
 
-  const startedAtResult = await runCommandWithOutput('docker', ['inspect', '--format', '{{.State.StartedAt}}', containerId], {
-    timeoutMs: 1000,
-  })
+  const startedAtResult = await runCommandWithOutput(
+    'docker',
+    ['inspect', '--format', '{{.State.StartedAt}}', containerId],
+    {
+      timeoutMs: 1000,
+    },
+  )
   if (!startedAtResult.ok || startedAtResult.code !== 0) {
     return null
   }
@@ -197,7 +203,7 @@ export const runInfo = async (options: InfoOptions): Promise<number> => {
       'http://127.0.0.1:7070/?page=i2p_tunnels',
     ])
 
-    const matches = new Set((`${result.stdout}\n${result.stderr}`).match(/[a-z2-7]{52}\.b32\.i2p/g) ?? [])
+    const matches = new Set(`${result.stdout}\n${result.stderr}`.match(/[a-z2-7]{52}\.b32\.i2p/g) ?? [])
     if (matches.size > 0) {
       if (options.json) {
         writeJson({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`getEventCount()` in `src/cli/commands/info.ts` opened a `knex` connection pool for a single ad-hoc query. When the initial connection attempt itself failed or timed out, the pool's `destroy()` resolved without actually closing the underlying socket, leaving an open handle behind and keeping the Node process alive indefinitely.

Replaces the `knex` pool with a raw `pg.Client` (`connect()` / `query()` / `end()`), which reliably closes its socket even when the connection attempt itself fails.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
Closes #739.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`nostream info` (and `nostream info --json`) would hang forever with no error or timeout if the configured database was unreachable, instead of failing cleanly like every other CLI command.



