### PR TITLE
feat(deploy): bake migrations into relay image, migrate from same image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ ADD resources /app/resources
 
 COPY --from=build /build/dist .
 COPY --from=build /build/package.json /build/pnpm-lock.yaml ./
+COPY --from=build /build/migrations ./migrations
+COPY --from=build /build/knexfile.js ./knexfile.js
 
 RUN corepack enable && corepack prepare pnpm@$PNPM_VERSION --activate && pnpm install --prod --frozen-lockfile --silent
 

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -71,18 +71,17 @@ services:
       retries: 10
 
   nostream-migrate:
-    image: nostream-migrate:local
+    image: ghcr.io/cameri/nostream:main
     pull_policy: never
     container_name: nostream-migrate
+    user: node:node
+    command: ['node_modules/.bin/knex', 'migrate:latest']
     environment:
       DB_HOST: nostream-db
       DB_PORT: 5432
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
       DB_NAME: ${DB_NAME}
-    volumes:
-      - ./migrations:/code/migrations
-      - ./knexfile.js:/code/knexfile.js
     depends_on:
       nostream-db:
         condition: service_healthy


### PR DESCRIPTION
## Summary

The relay image (`ghcr.io/cameri/nostream:main`) ships without `migrations/` or `knexfile.js`, so relay-server operators must hand-maintain a separate migrate image plus host-mounted migration files — which silently drifts from the code that ships.

- Bake `migrations/` and `knexfile.js` into the Docker runtime stage
- Point `deploy/docker-compose.prod.yml`'s `nostream-migrate` service at the relay image itself (`node_modules/.bin/knex migrate:latest`)
- One artifact, one pull; compose recreates the one-shot migrate container whenever the image digest changes, so migrations re-run on every release with no extra flags

## Verification

Built the image locally and ran the migrate command against a throwaway postgres:15: all 32 migrations applied (`Batch 1 run: 32 migrations`), exit 0, `knex_migrations` shows 32 rows with `20260812_150000_create_dvm_jobs_table.js` latest. Repo hooks (biome lint, build:check, unit tests) pass.