### PR TITLE
feat(deploy): minimal server bootstrap with optional settings overrides

### DIFF
--- a/.changeset/deploy-minimal-bootstrap.md
+++ b/.changeset/deploy-minimal-bootstrap.md
@@ -1,0 +1,9 @@
+---
+"nostream": patch
+---
+
+deploy: minimal server bootstrap with optional settings overrides
+
+Add deploy/bootstrap.sh, document what operators must keep locally vs what
+ships in the image, and stop seeding a full settings.yaml on first boot so
+release defaults merge with optional overrides only.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,112 +1,112 @@
 # Production deployment
 
 Minimal Docker Compose stack for running nostream in production. The relay
-container uses a pre-built image from GHCR instead of building on the server.
+uses a pre-built image from GHCR; migrations and default settings ship inside
+that image.
 
+<<<<<<< Updated upstream
 This guide assumes a Linux host with Docker Engine and the Compose plugin
 installed. Container images are published automatically after CI succeeds on pushes to
 `main`. See [`docs/DEPLOYMENT.md`](../docs/DEPLOYMENT.md) for the CI/CD flow.
+=======
+## What the server keeps locally
+>>>>>>> Stashed changes
 
-Migrations ship inside that image (`migrations/` and `knexfile.js`). The
-`nostream-migrate` service is a one-shot container of the same image that
-runs `knex migrate:latest` before the relay starts.
+| Path | Required | Changes with releases? |
+|------|----------|------------------------|
+| `.env` | **Yes** | No — your secrets and tuning |
+| `.nostr/data/` | Created at runtime | No — Postgres data |
+| `docker-compose.yml` | Yes (via bootstrap) | **Yes** — re-run bootstrap or PR 2 auto-sync |
+| `postgresql.conf` | Yes (via bootstrap) | Rarely |
+| `.nostr/settings.yaml` | **Optional** | Your overrides only |
+
+**Do not copy** onto the host: `migrations/`, `knexfile.js`, or a full
+`settings.yaml` from older docs. Migrations run from the image; settings
+defaults come from the image and merge with any optional overrides file.
+
+## Quick start
+
+From a git checkout on the server (or after copying the `deploy/` folder):
+
+```bash
+chmod +x deploy/bootstrap.sh
+./deploy/bootstrap.sh /opt/nostream
+```
+
+Edit `/opt/nostream/.env`, load `ghcr.io/cameri/nostream:main`, then:
+
+```bash
+cd /opt/nostream
+docker compose up -d
+```
+
+Bootstrap copies release-managed files (`docker-compose.yml`, `postgresql.conf`)
+from this repository. You only maintain `.env` and optional settings overrides.
 
 ## Prerequisites
 
-Before deploying the compose stack:
+1. [Docker Engine](https://docs.docker.com/engine/install/) and the Compose plugin
+2. `ghcr.io/cameri/nostream:main` loaded on the host (see
+   [Image delivery](#image-delivery-on-restricted-networks) if `docker pull` fails)
 
-1. Install [Docker Engine](https://docs.docker.com/engine/install/) and the
-   Compose plugin on the host.
-2. Create a deploy directory (for example `/opt/nostream`).
-3. Copy `deploy/docker-compose.prod.yml` to `docker-compose.yml` in that directory.
-4. Copy `deploy/settings.yaml.example` to `.nostr/settings.yaml` and edit for
-   your relay.
-5. Create `.env` from `deploy/env.example` with production secrets.
-6. Copy `postgresql.conf` from the repository root into the deploy directory.
-7. Load `ghcr.io/cameri/nostream:main` on the host (see
-   [Image delivery on restricted networks](#image-delivery-on-restricted-networks)
-   if `docker pull` fails).
-
-Do not copy `migrations/` or `knexfile.js` onto the host. Compose does not
-mount them; changing files on disk will not change what the migrate service
-runs.
-
-## Server layout
+## Server layout after bootstrap
 
 ```
 /opt/nostream/
-├── docker-compose.yml      # copy from deploy/docker-compose.prod.yml
+├── docker-compose.yml      # from deploy/docker-compose.prod.yml
+├── postgresql.conf         # from repository root
 ├── .env                    # secrets (never commit)
-├── .nostr/
-│   ├── settings.yaml       # copy from deploy/settings.yaml.example
-│   └── data/               # Postgres data (created on first start)
-└── postgresql.conf         # from repository root
+└── .nostr/
+    ├── settings.yaml       # optional overrides only
+    └── data/               # Postgres data (created on first start)
 ```
 
 ## Services
 
-| Service           | Image                          | Notes                                                      |
-|-------------------|--------------------------------|------------------------------------------------------------|
-| nostream          | ghcr.io/cameri/nostream:main   | `pull_policy: never` when the image is pre-loaded          |
-| nostream-db       | postgres:15                    |                                                            |
-| nostream-cache    | redis:7.0.5-alpine3.16         |                                                            |
-| nostream-migrate  | ghcr.io/cameri/nostream:main   | one-shot `knex migrate:latest`; same image as the relay    |
+| Service           | Image                          | Notes                                                   |
+|-------------------|--------------------------------|---------------------------------------------------------|
+| nostream          | ghcr.io/cameri/nostream:main   | `pull_policy: never` when the image is pre-loaded       |
+| nostream-db       | postgres:15                    |                                                         |
+| nostream-cache    | redis:7.0.5-alpine3.16         |                                                         |
+| nostream-migrate  | ghcr.io/cameri/nostream:main   | one-shot `knex migrate:latest`; same image as the relay |
 
-The relay listens on `127.0.0.1:8008` by default. Expose it publicly with a
-reverse proxy or tunnel (for example Cloudflare Tunnel) in front of that address.
+The relay listens on `127.0.0.1:8008`. Expose it with a reverse proxy or
+tunnel (for example Cloudflare Tunnel).
 
-The relay service waits for `nostream-migrate` to exit 0
-(`service_completed_successfully`) before it starts.
+The relay waits for `nostream-migrate` to exit 0 before it starts.
 
-## Deploy
+## Settings
+
+Without `.nostr/settings.yaml`, the relay uses `resources/default-settings.yaml`
+from the container image. When a release adds new settings keys, they appear
+automatically from the image defaults.
+
+To override specific values:
 
 ```bash
-cd /opt/nostream
-
-mkdir -p .nostr/data .nostr/db-logs
-chmod 755 .nostr
-chown 1000:1000 .nostr/settings.yaml
-chmod 600 .env .nostr/settings.yaml
-
-docker pull postgres:15
-docker pull redis:7.0.5-alpine3.16
-
+cp deploy/settings.yaml.example /opt/nostream/.nostr/settings.yaml
+# edit overrides only — not a full copy of default-settings.yaml
+chown 1000:1000 /opt/nostream/.nostr/settings.yaml
+chmod 600 /opt/nostream/.nostr/settings.yaml
 docker compose up -d
-docker compose logs -f nostream-migrate
-docker compose logs -f nostream
 ```
+
+Or use the admin API/UI once `admin.enabled` is configured.
 
 ## Verify
 
 ```bash
 docker compose ps
-curl -s http://127.0.0.1:8008/
 curl -s -H 'Accept: application/nostr+json' http://127.0.0.1:8008/
 ```
 
-The second command should return NIP-11 relay metadata JSON.
-
 ## Image delivery on restricted networks
 
-Some hosts cannot reach GHCR over IPv4. Workarounds:
+Some hosts cannot reach GHCR over IPv4:
 
 - **nostream image:** build or pull elsewhere, then `docker save` → transfer →
-  `docker load` on the server. Keep `pull_policy: never` on the nostream and
-  nostream-migrate services. One image is enough; migrations are already in it.
-- **postgres / redis:** usually available from Docker Hub; if not, use the same
-  save/load approach.
-
-## Settings file permissions
-
-The nostream container runs as the `node` user (uid 1000). Ensure
-`.nostr/settings.yaml` is owned by uid 1000 and readable by that user:
-
-```bash
-chown 1000:1000 .nostr/settings.yaml
-chmod 600 .nostr/settings.yaml
-```
-
-Without this, the relay falls back to default settings from the image.
+  `docker load`. Keep `pull_policy: never` on nostream and nostream-migrate.
+- **postgres / redis:** usually on Docker Hub; use save/load if needed.
 
 ## Updating
 
@@ -117,13 +117,19 @@ docker pull ghcr.io/cameri/nostream:main   # or: docker load -i nostream-main.ta
 docker compose up -d
 ```
 
-`pull_policy: never` means Compose will not fetch a new digest by itself.
-Load or pull the image first, then `up`. Compose recreates containers whose
-image id changed, so `nostream-migrate` runs `migrate:latest` against the
-schema baked into that image (no-op when already applied).
-
-If migrate does not re-run after a load, recreate it explicitly:
+If migrate does not re-run after a load:
 
 ```bash
 docker compose up -d --force-recreate nostream-migrate nostream
 ```
+
+When compose or `postgresql.conf` change in a release, re-run bootstrap against
+the new checkout (or copy the updated files). Automated sync is planned separately.
+
+## Refresh release-managed files
+
+```bash
+./deploy/bootstrap.sh /opt/nostream
+```
+
+Existing `.env` and `.nostr/settings.yaml` are preserved.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -4,13 +4,11 @@ Minimal Docker Compose stack for running nostream in production. The relay
 uses a pre-built image from GHCR; migrations and default settings ship inside
 that image.
 
-<<<<<<< Updated upstream
 This guide assumes a Linux host with Docker Engine and the Compose plugin
 installed. Container images are published automatically after CI succeeds on pushes to
 `main`. See [`docs/DEPLOYMENT.md`](../docs/DEPLOYMENT.md) for the CI/CD flow.
-=======
+
 ## What the server keeps locally
->>>>>>> Stashed changes
 
 | Path | Required | Changes with releases? |
 |------|----------|------------------------|

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -84,7 +84,9 @@ To override specific values:
 ```bash
 cp deploy/settings.yaml.example /opt/nostream/.nostr/settings.yaml
 # edit overrides only — not a full copy of default-settings.yaml
-chown 1000:1000 /opt/nostream/.nostr/settings.yaml
+# the relay also writes backups and the audit log into .nostr itself, so the
+# directory needs to be writable by uid 1000, not just the settings file
+chown 1000:1000 /opt/nostream/.nostr /opt/nostream/.nostr/settings.yaml
 chmod 600 /opt/nostream/.nostr/settings.yaml
 docker compose up -d
 ```

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -44,6 +44,13 @@ else
   echo "Keeping existing $TARGET/.nostr/settings.yaml"
 fi
 
+# The relay container runs as node (uid 1000) and writes settings.yaml, backups,
+# and the audit log directly under .nostr. Deliberately not recursive: .nostr/data
+# and .nostr/db-logs are owned by the postgres image's own user.
+if [[ "$(id -u)" -eq 0 ]]; then
+  chown 1000:1000 "$TARGET/.nostr"
+fi
+
 chmod 755 "$TARGET/.nostr"
 
 cat <<EOF

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bootstrap a production nostream host from this repository's deploy/ directory.
+#
+# Usage:
+#   ./deploy/bootstrap.sh [/opt/nostream]
+#
+# Creates the server layout, copies release-managed files from deploy/, and
+# prepares .env for secrets. settings.yaml is optional — the relay uses image
+# defaults until you add overrides (admin UI/API or .nostr/settings.yaml).
+
+TARGET="${1:-/opt/nostream}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+require_file() {
+  if [[ ! -f "$1" ]]; then
+    echo "error: required file not found: $1" >&2
+    exit 1
+  fi
+}
+
+require_file "$SCRIPT_DIR/docker-compose.prod.yml"
+require_file "$SCRIPT_DIR/env.example"
+require_file "$REPO_ROOT/postgresql.conf"
+
+mkdir -p "$TARGET/.nostr/data" "$TARGET/.nostr/db-logs"
+
+install -m 644 "$SCRIPT_DIR/docker-compose.prod.yml" "$TARGET/docker-compose.yml"
+install -m 644 "$REPO_ROOT/postgresql.conf" "$TARGET/postgresql.conf"
+
+if [[ ! -f "$TARGET/.env" ]]; then
+  install -m 600 "$SCRIPT_DIR/env.example" "$TARGET/.env"
+  echo "Created $TARGET/.env — edit secrets before starting the stack."
+else
+  echo "Keeping existing $TARGET/.env"
+fi
+
+if [[ ! -f "$TARGET/.nostr/settings.yaml" ]]; then
+  echo "No settings.yaml created — relay will use defaults from the container image."
+  echo "Add overrides later via the admin API or copy deploy/settings.yaml.example."
+else
+  echo "Keeping existing $TARGET/.nostr/settings.yaml"
+fi
+
+chmod 755 "$TARGET/.nostr"
+
+cat <<EOF
+
+Bootstrap complete: $TARGET
+
+Next steps:
+  1. Edit $TARGET/.env (SECRET, DB_PASSWORD, REDIS_PASSWORD)
+  2. Load ghcr.io/cameri/nostream:main on this host
+  3. cd $TARGET && docker compose up -d
+
+Optional relay overrides:
+  cp $SCRIPT_DIR/settings.yaml.example $TARGET/.nostr/settings.yaml
+  chown 1000:1000 $TARGET/.nostr/settings.yaml
+  chmod 600 $TARGET/.nostr/settings.yaml
+
+EOF

--- a/deploy/settings.yaml.example
+++ b/deploy/settings.yaml.example
@@ -1,26 +1,18 @@
-# Copy to .nostr/settings.yaml on the server and edit for your relay.
-# Values here override resources/default-settings.yaml from the image.
+# Optional relay overrides — copy to .nostr/settings.yaml only when needed.
+# Omit this file entirely to run with resources/default-settings.yaml from the image.
+# Values here override image defaults (deep merge). New release keys come from the image automatically.
 
 info:
-  relay_url: wss://relay.tnsor.network
-  name: relay.tnsor.network
+  relay_url: wss://relay.example.com
+  name: relay.example.com
   description: A Nostr relay powered by nostream.
-  pubkey: ""
-  contact: mailto:operator@tnsor.network
-  terms_of_service: https://relay.tnsor.network/terms
-  privacy_policy: https://relay.tnsor.network/privacy
+  contact: mailto:operator@example.com
 
-payments:
-  enabled: false
+# payments:
+#   enabled: false
 
-nip45:
-  enabled: true
+# nip66:
+#   enabled: false
 
-nip66:
-  enabled: false
-
-workers:
-  count: 2
-
-admin:
-  enabled: false
+# admin:
+#   enabled: false

--- a/src/utils/settings-config.ts
+++ b/src/utils/settings-config.ts
@@ -3,10 +3,12 @@ import { join } from 'path'
 import yaml from 'js-yaml'
 import { mergeDeepRight } from 'ramda'
 
+import { createLogger } from '../factories/logger-factory'
 import { Settings } from '../@types/settings'
 import {
   getConfigBaseDir,
   getDefaultSettingsFilePath,
+  getLegacySettingsFilePath,
   getSettingsAuditLogPath,
   getSettingsBackupDir,
   getSettingsFilePath,
@@ -15,10 +17,13 @@ import {
 export {
   getConfigBaseDir,
   getDefaultSettingsFilePath,
+  getLegacySettingsFilePath,
   getSettingsAuditLogPath,
   getSettingsBackupDir,
   getSettingsFilePath,
 } from './settings-paths'
+
+const logger = createLogger('settings-config')
 
 export type ValidationIssue = {
   path: string
@@ -302,12 +307,20 @@ export const loadUserSettings = (): Settings => {
   ensureSettingsExists()
   const settingsPath = getSettingsFilePath()
 
-  if (!fs.existsSync(settingsPath)) {
-    return {} as Settings
+  if (fs.existsSync(settingsPath)) {
+    const raw = fs.readFileSync(settingsPath, 'utf-8')
+    return (yaml.load(raw) as Settings) ?? ({} as Settings)
   }
 
-  const raw = fs.readFileSync(settingsPath, 'utf-8')
-  return (yaml.load(raw) as Settings) ?? ({} as Settings)
+  // Deployments predating the yaml migration still hold their overrides in
+  // settings.json. Ignoring it would silently reset them to image defaults.
+  const legacyPath = getLegacySettingsFilePath()
+  if (fs.existsSync(legacyPath)) {
+    logger.warn('settings.json is deprecated, please migrate your overrides to %s', settingsPath)
+    return (JSON.parse(fs.readFileSync(legacyPath, 'utf-8')) as Settings) ?? ({} as Settings)
+  }
+
+  return {} as Settings
 }
 
 export const loadMergedSettings = (): Settings => {

--- a/src/utils/settings-config.ts
+++ b/src/utils/settings-config.ts
@@ -4,6 +4,21 @@ import yaml from 'js-yaml'
 import { mergeDeepRight } from 'ramda'
 
 import { Settings } from '../@types/settings'
+import {
+  getConfigBaseDir,
+  getDefaultSettingsFilePath,
+  getSettingsAuditLogPath,
+  getSettingsBackupDir,
+  getSettingsFilePath,
+} from './settings-paths'
+
+export {
+  getConfigBaseDir,
+  getDefaultSettingsFilePath,
+  getSettingsAuditLogPath,
+  getSettingsBackupDir,
+  getSettingsFilePath,
+} from './settings-paths'
 
 export type ValidationIssue = {
   path: string
@@ -19,16 +34,6 @@ type PathToken =
       type: 'index'
       index: number
     }
-
-export const getConfigBaseDir = (): string => process.env.NOSTR_CONFIG_DIR ?? join(process.cwd(), '.nostr')
-
-export const getSettingsFilePath = (): string => join(getConfigBaseDir(), 'settings.yaml')
-
-export const getDefaultSettingsFilePath = (): string => join(process.cwd(), 'resources', 'default-settings.yaml')
-
-export const getSettingsBackupDir = (): string => join(getConfigBaseDir(), 'backups')
-
-export const getSettingsAuditLogPath = (): string => join(getConfigBaseDir(), 'settings-audit.jsonl')
 
 export const toCategoryLabel = (key: string): string => {
   return key
@@ -282,15 +287,9 @@ const pathExistsInSchema = (schema: unknown, tokens: PathToken[]): boolean => {
 
 export const ensureSettingsExists = (): void => {
   const configDir = getConfigBaseDir()
-  const settingsPath = getSettingsFilePath()
-  const defaultsPath = getDefaultSettingsFilePath()
 
   if (!fs.existsSync(configDir)) {
     fs.mkdirSync(configDir, { recursive: true })
-  }
-
-  if (!fs.existsSync(settingsPath)) {
-    fs.copyFileSync(defaultsPath, settingsPath)
   }
 }
 
@@ -301,7 +300,13 @@ export const loadDefaults = (): Settings => {
 
 export const loadUserSettings = (): Settings => {
   ensureSettingsExists()
-  const raw = fs.readFileSync(getSettingsFilePath(), 'utf-8')
+  const settingsPath = getSettingsFilePath()
+
+  if (!fs.existsSync(settingsPath)) {
+    return {} as Settings
+  }
+
+  const raw = fs.readFileSync(settingsPath, 'utf-8')
   return (yaml.load(raw) as Settings) ?? ({} as Settings)
 }
 

--- a/src/utils/settings-paths.ts
+++ b/src/utils/settings-paths.ts
@@ -4,6 +4,9 @@ export const getConfigBaseDir = (): string => process.env.NOSTR_CONFIG_DIR ?? jo
 
 export const getSettingsFilePath = (): string => join(getConfigBaseDir(), 'settings.yaml')
 
+/** Deprecated pre-yaml settings file, still read as a fallback so existing deployments keep their overrides. */
+export const getLegacySettingsFilePath = (): string => join(getConfigBaseDir(), 'settings.json')
+
 export const getDefaultSettingsFilePath = (): string => join(process.cwd(), 'resources', 'default-settings.yaml')
 
 export const getSettingsBackupDir = (): string => join(getConfigBaseDir(), 'backups')

--- a/src/utils/settings-paths.ts
+++ b/src/utils/settings-paths.ts
@@ -1,0 +1,11 @@
+import { join } from 'path'
+
+export const getConfigBaseDir = (): string => process.env.NOSTR_CONFIG_DIR ?? join(process.cwd(), '.nostr')
+
+export const getSettingsFilePath = (): string => join(getConfigBaseDir(), 'settings.yaml')
+
+export const getDefaultSettingsFilePath = (): string => join(process.cwd(), 'resources', 'default-settings.yaml')
+
+export const getSettingsBackupDir = (): string => join(getConfigBaseDir(), 'backups')
+
+export const getSettingsAuditLogPath = (): string => join(getConfigBaseDir(), 'settings-audit.jsonl')

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -2,10 +2,11 @@ import fs from 'fs'
 import yaml from 'js-yaml'
 
 import { extname, join } from 'path'
-import { mergeDeepRight } from 'ramda'
 
 import { createLogger } from '../factories/logger-factory'
 import { Settings } from '../@types/settings'
+import { loadDefaults, loadMergedSettings } from './settings-config'
+import { getConfigBaseDir, getDefaultSettingsFilePath, getSettingsFilePath } from './settings-paths'
 
 const logger = createLogger('settings')
 
@@ -18,11 +19,11 @@ export class SettingsStatic {
   static _settings: Settings | undefined
 
   public static getSettingsFileBasePath(): string {
-    return process.env.NOSTR_CONFIG_DIR ?? join(process.cwd(), '.nostr')
+    return getConfigBaseDir()
   }
 
   public static getDefaultSettingsFilePath(): string {
-    return join(process.cwd(), 'resources', 'default-settings.yaml')
+    return getDefaultSettingsFilePath()
   }
 
   public static loadAndParseYamlFile(path: string): Settings {
@@ -71,23 +72,15 @@ export class SettingsStatic {
     }
     logger('creating settings')
 
-    const basePath = SettingsStatic.getSettingsFileBasePath()
+    const basePath = getConfigBaseDir()
     if (!fs.existsSync(basePath)) {
-      fs.mkdirSync(basePath)
+      fs.mkdirSync(basePath, { recursive: true })
     }
-    const defaultsFilePath = SettingsStatic.getDefaultSettingsFilePath()
-    const fileType = SettingsStatic.settingsFileType(basePath)
-    const settingsFilePath = join(basePath, `settings.${fileType}`)
 
-    const defaults = SettingsStatic.loadSettings(defaultsFilePath, SettingsFileTypes.yaml)
+    const settingsFilePath = getSettingsFilePath()
 
     try {
-      if (fileType) {
-        SettingsStatic._settings = mergeDeepRight(defaults, SettingsStatic.loadSettings(settingsFilePath, fileType))
-      } else {
-        SettingsStatic.saveSettings(basePath, defaults)
-        SettingsStatic._settings = mergeDeepRight({}, defaults)
-      }
+      SettingsStatic._settings = loadMergedSettings()
 
       if (typeof SettingsStatic._settings === 'undefined') {
         throw new Error('Unable to set settings')
@@ -97,7 +90,8 @@ export class SettingsStatic {
     } catch (error) {
       logger('error reading config file at %s: %o', settingsFilePath, error)
 
-      return defaults
+      SettingsStatic._settings = loadDefaults()
+      return SettingsStatic._settings
     }
   }
 
@@ -107,8 +101,8 @@ export class SettingsStatic {
   }
 
   public static watchSettings() {
-    const basePath = SettingsStatic.getSettingsFileBasePath()
-    const defaultsFilePath = SettingsStatic.getDefaultSettingsFilePath()
+    const basePath = getConfigBaseDir()
+    const defaultsFilePath = getDefaultSettingsFilePath()
     const fileType = SettingsStatic.settingsFileType(basePath)
 
     const reload = () => {

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -5,7 +5,7 @@ import { extname, join } from 'path'
 
 import { createLogger } from '../factories/logger-factory'
 import { Settings } from '../@types/settings'
-import { loadDefaults, loadMergedSettings } from './settings-config'
+import { ensureSettingsExists, loadDefaults, loadMergedSettings } from './settings-config'
 import { getConfigBaseDir, getDefaultSettingsFilePath, getSettingsFilePath } from './settings-paths'
 
 const logger = createLogger('settings')
@@ -103,6 +103,11 @@ export class SettingsStatic {
   public static watchSettings() {
     const basePath = getConfigBaseDir()
     const defaultsFilePath = getDefaultSettingsFilePath()
+
+    // Workers can reach watchSettings() before any process has run createSettings(),
+    // and both settingsFileType() and fs.watch() throw if the config dir is missing.
+    ensureSettingsExists()
+
     const fileType = SettingsStatic.settingsFileType(basePath)
 
     const reload = () => {

--- a/test/unit/utils/settings-config.spec.ts
+++ b/test/unit/utils/settings-config.spec.ts
@@ -142,4 +142,43 @@ describe('settings-guided-schema', () => {
       }
     }
   })
+
+  it('falls back to deprecated settings.json when settings.yaml is absent', () => {
+    const originalConfigDir = process.env.NOSTR_CONFIG_DIR
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nostream-settings-legacy-'))
+
+    try {
+      process.env.NOSTR_CONFIG_DIR = tmpDir
+      fs.writeFileSync(path.join(tmpDir, 'settings.json'), JSON.stringify({ info: { name: 'legacy' } }))
+
+      expect(loadUserSettings()).to.deep.equal({ info: { name: 'legacy' } })
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+      if (originalConfigDir === undefined) {
+        delete process.env.NOSTR_CONFIG_DIR
+      } else {
+        process.env.NOSTR_CONFIG_DIR = originalConfigDir
+      }
+    }
+  })
+
+  it('prefers settings.yaml over deprecated settings.json', () => {
+    const originalConfigDir = process.env.NOSTR_CONFIG_DIR
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nostream-settings-precedence-'))
+
+    try {
+      process.env.NOSTR_CONFIG_DIR = tmpDir
+      fs.writeFileSync(path.join(tmpDir, 'settings.json'), JSON.stringify({ info: { name: 'legacy' } }))
+      fs.writeFileSync(path.join(tmpDir, 'settings.yaml'), 'info:\n  name: current\n')
+
+      expect(loadUserSettings()).to.deep.equal({ info: { name: 'current' } })
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+      if (originalConfigDir === undefined) {
+        delete process.env.NOSTR_CONFIG_DIR
+      } else {
+        process.env.NOSTR_CONFIG_DIR = originalConfigDir
+      }
+    }
+  })
 })

--- a/test/unit/utils/settings-config.spec.ts
+++ b/test/unit/utils/settings-config.spec.ts
@@ -1,6 +1,11 @@
 import { expect } from 'chai'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
 
 import {
+  ensureSettingsExists,
+  loadUserSettings,
   toCategoryLabel,
   getByPath,
   getTopLevelSettingCategories,
@@ -117,5 +122,24 @@ describe('settings-guided-schema', () => {
     expect(requireSafeNonNegativeIntegerSettingValue('bad')).to.equal('Value must be a non-negative integer')
     expect(requireSafeNonNegativeIntegerSettingValue('2048')).to.equal(undefined)
     expect(requireNonEmptySettingValue(' ')).to.equal('Value is required')
+  })
+
+  it('does not create settings.yaml when ensuring config dir exists', () => {
+    const originalConfigDir = process.env.NOSTR_CONFIG_DIR
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nostream-settings-config-'))
+
+    try {
+      process.env.NOSTR_CONFIG_DIR = tmpDir
+      ensureSettingsExists()
+      expect(loadUserSettings()).to.deep.equal({})
+      expect(fs.existsSync(path.join(tmpDir, 'settings.yaml'))).to.equal(false)
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+      if (originalConfigDir === undefined) {
+        delete process.env.NOSTR_CONFIG_DIR
+      } else {
+        process.env.NOSTR_CONFIG_DIR = originalConfigDir
+      }
+    }
   })
 })

--- a/test/unit/utils/settings-paths.spec.ts
+++ b/test/unit/utils/settings-paths.spec.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai'
+
+import {
+  getConfigBaseDir,
+  getDefaultSettingsFilePath,
+  getSettingsAuditLogPath,
+  getSettingsBackupDir,
+  getSettingsFilePath,
+} from '../../../src/utils/settings-paths'
+
+describe('settings paths', () => {
+  const originalConfigDir = process.env.NOSTR_CONFIG_DIR
+
+  afterEach(() => {
+    if (originalConfigDir === undefined) {
+      delete process.env.NOSTR_CONFIG_DIR
+    } else {
+      process.env.NOSTR_CONFIG_DIR = originalConfigDir
+    }
+  })
+
+  it('defaults config dir to .nostr under cwd', () => {
+    delete process.env.NOSTR_CONFIG_DIR
+
+    expect(getConfigBaseDir()).to.equal(`${process.cwd()}/.nostr`)
+    expect(getSettingsFilePath()).to.equal(`${process.cwd()}/.nostr/settings.yaml`)
+    expect(getSettingsBackupDir()).to.equal(`${process.cwd()}/.nostr/backups`)
+    expect(getSettingsAuditLogPath()).to.equal(`${process.cwd()}/.nostr/settings-audit.jsonl`)
+  })
+
+  it('honors NOSTR_CONFIG_DIR', () => {
+    process.env.NOSTR_CONFIG_DIR = '/srv/nostream/.nostr'
+
+    expect(getConfigBaseDir()).to.equal('/srv/nostream/.nostr')
+    expect(getSettingsFilePath()).to.equal('/srv/nostream/.nostr/settings.yaml')
+  })
+
+  it('points default settings at bundled resources file', () => {
+    expect(getDefaultSettingsFilePath()).to.equal(`${process.cwd()}/resources/default-settings.yaml`)
+  })
+})

--- a/test/unit/utils/settings-paths.spec.ts
+++ b/test/unit/utils/settings-paths.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai'
+import { join } from 'path'
 
 import {
   getConfigBaseDir,
@@ -22,20 +23,20 @@ describe('settings paths', () => {
   it('defaults config dir to .nostr under cwd', () => {
     delete process.env.NOSTR_CONFIG_DIR
 
-    expect(getConfigBaseDir()).to.equal(`${process.cwd()}/.nostr`)
-    expect(getSettingsFilePath()).to.equal(`${process.cwd()}/.nostr/settings.yaml`)
-    expect(getSettingsBackupDir()).to.equal(`${process.cwd()}/.nostr/backups`)
-    expect(getSettingsAuditLogPath()).to.equal(`${process.cwd()}/.nostr/settings-audit.jsonl`)
+    expect(getConfigBaseDir()).to.equal(join(process.cwd(), '.nostr'))
+    expect(getSettingsFilePath()).to.equal(join(process.cwd(), '.nostr', 'settings.yaml'))
+    expect(getSettingsBackupDir()).to.equal(join(process.cwd(), '.nostr', 'backups'))
+    expect(getSettingsAuditLogPath()).to.equal(join(process.cwd(), '.nostr', 'settings-audit.jsonl'))
   })
 
   it('honors NOSTR_CONFIG_DIR', () => {
     process.env.NOSTR_CONFIG_DIR = '/srv/nostream/.nostr'
 
     expect(getConfigBaseDir()).to.equal('/srv/nostream/.nostr')
-    expect(getSettingsFilePath()).to.equal('/srv/nostream/.nostr/settings.yaml')
+    expect(getSettingsFilePath()).to.equal(join('/srv/nostream/.nostr', 'settings.yaml'))
   })
 
   it('points default settings at bundled resources file', () => {
-    expect(getDefaultSettingsFilePath()).to.equal(`${process.cwd()}/resources/default-settings.yaml`)
+    expect(getDefaultSettingsFilePath()).to.equal(join(process.cwd(), 'resources', 'default-settings.yaml'))
   })
 })

--- a/test/unit/utils/settings.spec.ts
+++ b/test/unit/utils/settings.spec.ts
@@ -6,6 +6,7 @@ import { mergeDeepRight } from 'ramda'
 import { Settings } from '../../../src/@types/settings'
 
 import { SettingsFileTypes, SettingsStatic } from '../../../src/utils/settings'
+import * as settingsConfig from '../../../src/utils/settings-config'
 
 describe('SettingsStatic', () => {
   describe('.getSettingsFilePath', () => {
@@ -147,12 +148,8 @@ describe('SettingsStatic', () => {
   describe('.createSettings', () => {
     let existsSyncStub: Sinon.SinonStub
     let mkdirSyncStub: Sinon.SinonStub
-    let readdirSyncStub: Sinon.SinonStub
-    let getSettingsFileBasePathStub: Sinon.SinonStub
-    let getDefaultSettingsFilePathStub: Sinon.SinonStub
-    let settingsFileTypeStub: Sinon.SinonStub
-    let saveSettingsStub: Sinon.SinonStub
-    let loadSettingsStub: Sinon.SinonStub
+    let loadMergedSettingsStub: Sinon.SinonStub
+    let loadDefaultsStub: Sinon.SinonStub
 
     let sandbox: Sinon.SinonSandbox
 
@@ -163,67 +160,34 @@ describe('SettingsStatic', () => {
 
       existsSyncStub = sandbox.stub(fs, 'existsSync')
       mkdirSyncStub = sandbox.stub(fs, 'mkdirSync')
-      readdirSyncStub = sandbox.stub(fs, 'readdirSync')
-      getSettingsFileBasePathStub = sandbox.stub(SettingsStatic, 'getSettingsFileBasePath')
-      getDefaultSettingsFilePathStub = sandbox.stub(SettingsStatic, 'getDefaultSettingsFilePath')
-      settingsFileTypeStub = sandbox.stub(SettingsStatic, 'settingsFileType')
-      saveSettingsStub = sandbox.stub(SettingsStatic, 'saveSettings')
-      loadSettingsStub = sandbox.stub(SettingsStatic, 'loadSettings')
+      loadMergedSettingsStub = sandbox.stub(settingsConfig, 'loadMergedSettings')
+      loadDefaultsStub = sandbox.stub(settingsConfig, 'loadDefaults')
     })
 
     afterEach(() => {
       sandbox.restore()
     })
 
-    it('creates settings from defaults if settings file is missing', () => {
-      getSettingsFileBasePathStub.returns('/some/path/settings.yaml')
+    it('loads merged settings from defaults and optional overrides', () => {
       existsSyncStub.returns(false)
       mkdirSyncStub.returns(true)
-      readdirSyncStub.returns(['file.yaml'])
-      loadSettingsStub.returns({})
+      loadMergedSettingsStub.returns({ info: { name: 'relay' } })
 
-      expect(SettingsStatic.createSettings()).to.be.an('object')
-
-      expect(existsSyncStub).to.have.been.calledOnceWithExactly('/some/path/settings.yaml')
-      expect(getSettingsFileBasePathStub).to.have.been.calledOnce
-      expect(saveSettingsStub).to.have.been.calledOnceWithExactly('/some/path/settings.yaml', Sinon.match.object)
-      expect(loadSettingsStub).to.have.been.called
+      expect(SettingsStatic.createSettings()).to.deep.equal({ info: { name: 'relay' } })
+      expect(loadMergedSettingsStub).to.have.been.calledOnce
+      expect(loadDefaultsStub).not.to.have.been.called
     })
 
-    it('returns default settings if saving settings file throws', () => {
-      const error = new Error('mistakes were made')
-      getSettingsFileBasePathStub.returns('/some/path/settings.json')
-      saveSettingsStub.throws(error)
+    it('returns image defaults if loading merged settings throws', () => {
       existsSyncStub.returns(false)
-      readdirSyncStub.returns(['file.yaml'])
-      loadSettingsStub.returns({})
+      mkdirSyncStub.returns(true)
+      loadMergedSettingsStub.throws(new Error('mistakes were made'))
+      loadDefaultsStub.returns({ info: { name: 'default-relay' } })
 
-      expect(SettingsStatic.createSettings()).to.be.an('object')
+      expect(SettingsStatic.createSettings()).to.deep.equal({ info: { name: 'default-relay' } })
 
-      const settingsPathExistsChecks = existsSyncStub.getCalls().filter((call) => {
-        return call.args.length === 1 && call.args[0] === '/some/path/settings.json'
-      })
-
-      expect(settingsPathExistsChecks).to.have.lengthOf(1)
-      expect(getSettingsFileBasePathStub).to.have.been.calledOnce
-      expect(saveSettingsStub).to.have.been.calledOnceWithExactly('/some/path/settings.json', Sinon.match.object)
-      expect(loadSettingsStub).to.have.been.called
-    })
-
-    it('loads settings from file if settings file exists', () => {
-      loadSettingsStub.returns({ test: 'value' })
-      getSettingsFileBasePathStub.returns('/some/path/settings.yaml')
-      getDefaultSettingsFilePathStub.returns('/some/path/settings.yaml')
-      existsSyncStub.returns(true)
-      readdirSyncStub.returns(['settings.yaml'])
-      settingsFileTypeStub.returns('yaml')
-
-      expect(SettingsStatic.createSettings()).to.be.an('object')
-
-      expect(existsSyncStub).to.have.been.calledWithExactly('/some/path/settings.yaml')
-      expect(getSettingsFileBasePathStub).to.have.been.calledOnce
-      expect(saveSettingsStub).not.to.have.been.called
-      expect(loadSettingsStub).to.have.been.calledWithExactly('/some/path/settings.yaml', 'yaml')
+      expect(loadMergedSettingsStub).to.have.been.calledOnce
+      expect(loadDefaultsStub).to.have.been.calledOnce
     })
 
     it('returns cached settings if set', () => {
@@ -232,10 +196,8 @@ describe('SettingsStatic', () => {
 
       expect(SettingsStatic.createSettings()).to.equal(cachedSettings)
 
-      expect(getSettingsFileBasePathStub).not.to.have.been.calledOnce
       expect(existsSyncStub).not.to.have.been.called
-      expect(saveSettingsStub).not.to.have.been.called
-      expect(loadSettingsStub).not.to.have.been.called
+      expect(loadMergedSettingsStub).not.to.have.been.called
     })
   })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
On the sandbox server, compose and copied config files don't sync automatically when the repo changes. Operators shouldn't edit files that change every release. Settings especially should not require manual YAML updates when new config keys ship.
This PR  makes the bootstrap story minimal and fixes settings merge behavior so new release keys come from the image automatically.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related: #744, #748, #750
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Non-functional change (docs, style, minor refactor)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my code changes.
- [ ] I added a changeset, or this is docs-only and I added an empty changeset.
- [ ] All new and existing tests passed.
