### PR TITLE
chore: gitignore coverage-report/ output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ dist
 docker-compose.overrides.yml
 # Export output
 *.jsonl
+
+# Code coverage report output
+coverage-report/


### PR DESCRIPTION
Removes stray bisect-test.sh and ignores regenerable `coverage-report/` output.